### PR TITLE
Adjust to sphinx 1.2.2 that is Ubuntu Trusty default (revert some changes in #35)

### DIFF
--- a/doc/locale/en/LC_MESSAGES/1.1_demo_imageprocessing.po
+++ b/doc/locale/en/LC_MESSAGES/1.1_demo_imageprocessing.po
@@ -11,19 +11,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.1_demo_imageprocessing.rst:1
+#: ../../1.1_demo_imageprocessing.rst:1
 msgid "**(デモ 1) 画像処理 (OpenRTM-aist，OpenCV)**"
 msgstr "**(Demo1) Image Processing (OpenRTM-aist，OpenCV)**"
 
-#: ..\..\1.1_demo_imageprocessing.rst:11
+#: ../../1.1_demo_imageprocessing.rst:11
 msgid "Introduction"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:14
+#: ../../1.1_demo_imageprocessing.rst:14
 msgid "関連するチュートリアル"
 msgstr "Related Tutorials"
 
-#: ..\..\1.1_demo_imageprocessing.rst:15
+#: ../../1.1_demo_imageprocessing.rst:15
 msgid ""
 "http://www.openrtm.org/openrtm/ja/node/4625 - ネット接続不可の場合は "
 "./doc/tutorial_openrtm_opencv_cmake_imgprocessing.pdf"
@@ -31,19 +31,19 @@ msgstr ""
 "http://www.openrtm.org/openrtm/ja/node/4625 - If internet connection is not "
 "available, find it in:./doc/tutorial_openrtm_opencv_cmake_imgprocessing.pdf"
 
-#: ..\..\1.1_demo_imageprocessing.rst:19
+#: ../../1.1_demo_imageprocessing.rst:19
 msgid "このページで体験すること"
 msgstr "What you'll experience"
 
-#: ..\..\1.1_demo_imageprocessing.rst:20
+#: ../../1.1_demo_imageprocessing.rst:20
 msgid "カメラで認識する動画像を反転 (OpenRTM-aist，OpenCV による)"
 msgstr "Transform camera images (by OpenRTM-aist，OpenCV)"
 
-#: ..\..\1.1_demo_imageprocessing.rst:25
+#: ../../1.1_demo_imageprocessing.rst:25
 msgid "Windows 7／ 8"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:26
+#: ../../1.1_demo_imageprocessing.rst:26
 msgid ""
 "Java Runtime Environment (JRE) 7 "
 "(`../misc/openjdk_1.7.0_u45_2.4.3_installed` として同梱，インストール不要)"
@@ -51,64 +51,64 @@ msgstr ""
 "Java Runtime Environment (JRE) 7 (Bundled at "
 "`../misc/openjdk_1.7.0_u45_2.4.3_installed`, no need to install)"
 
-#: ..\..\1.1_demo_imageprocessing.rst:30
+#: ../../1.1_demo_imageprocessing.rst:30
 msgid "実行方法"
 msgstr "Run the tutorial"
 
-#: ..\..\1.1_demo_imageprocessing.rst:31
+#: ../../1.1_demo_imageprocessing.rst:31
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 "Your current directory is assumed to be the home of the USB unless "
 "specified."
 
-#: ..\..\1.1_demo_imageprocessing.rst:34
+#: ../../1.1_demo_imageprocessing.rst:34
 msgid "nameserver 起動 (全チュートリアル共通)"
 msgstr "Start CORBA nameserver (common throughout all tutorials)"
 
-#: ..\..\1.1_demo_imageprocessing.rst:35
+#: ../../1.1_demo_imageprocessing.rst:35
 msgid "基本的に `OpenRTM` の nameserver は一度起動すると，起動したままでもすべてのチュートリアルは動作すると思われます．"
 msgstr ""
 "Once you start, nameserver can be kept running throught all tutorials."
 
-#: ..\..\1.1_demo_imageprocessing.rst:37
+#: ../../1.1_demo_imageprocessing.rst:37
 msgid "次のリンクをクリックして nameserver を起動．"
 msgstr "Click the link to start nameserver."
 
-#: ..\..\1.1_demo_imageprocessing.rst:48
+#: ../../1.1_demo_imageprocessing.rst:48
 msgid "Starting omniNames for the first time. : Checkpointing completed."
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:52
+#: ../../1.1_demo_imageprocessing.rst:52
 msgid "上記手順で `cmd.exe` が消えてしまう場合は，`nameserver` がうまく起動していないので次の手順で原因を発見："
 msgstr ""
 "If `cmd.exe` doesn't stay, you're somehow failing to run `nameserver` so try"
 " to find the cause by the following:"
 
-#: ..\..\1.1_demo_imageprocessing.rst:54
+#: ../../1.1_demo_imageprocessing.rst:54
 msgid "2.1) `Explorer` 上で，USB のドライヴ名を確認 (D/E/F etc. ここでは `F` と仮定)"
 msgstr ""
 "2.1) On `Explorer`, check the drive letter of the tutorial USB (usually "
 "either D/E/F. Here we assume as `F`)"
 
-#: ..\..\1.1_demo_imageprocessing.rst:56
+#: ../../1.1_demo_imageprocessing.rst:56
 msgid "2.2) `cmd.exe` を手動起動 (Win 7: [4_], Win 8: [5_])"
 msgstr "2.2) Manually start `cmd.exe` (Win 7: [4_], Win 8: [5_])"
 
-#: ..\..\1.1_demo_imageprocessing.rst:58
+#: ../../1.1_demo_imageprocessing.rst:58
 msgid "2.3) 以下コマンドでフォルダ移動・コマンド実行::"
 msgstr "2.3) Run the following commands to move to the folder::"
 
-#: ..\..\1.1_demo_imageprocessing.rst:64
+#: ../../1.1_demo_imageprocessing.rst:64
 msgid ""
 "エラー等発生していればここで表示されるのでその内容を診断．`OpenRTM` の `nameserver` の問題は WEB "
 "で検索して対処してみてください．"
 msgstr "Diagnose errors. Many errors with `CORBA` can be found on the WEB."
 
-#: ..\..\1.1_demo_imageprocessing.rst:67
+#: ../../1.1_demo_imageprocessing.rst:67
 msgid "チュートリアルのプログラム実行"
 msgstr "Run programs in the tutorial"
 
-#: ..\..\1.1_demo_imageprocessing.rst:69
+#: ../../1.1_demo_imageprocessing.rst:69
 msgid ""
 "`./demo/OpencvRtmDemo/0_StartDemo.bat` を実行．次のリンクから起動できなければ，手動で `Explorer` "
 "から実行．"
@@ -116,15 +116,15 @@ msgstr ""
 "Run `./demo/OpencvRtmDemo/0_StartDemo.bat` by clicking on the link below. If"
 " it doesn't work, run it manually from `Explorer`."
 
-#: ..\..\1.1_demo_imageprocessing.rst:75
+#: ../../1.1_demo_imageprocessing.rst:75
 msgid "./demo/RTSE.bat を実行．"
 msgstr "Run ./demo/RTSE.bat."
 
-#: ..\..\1.1_demo_imageprocessing.rst:81
+#: ../../1.1_demo_imageprocessing.rst:81
 msgid "RT System Editor が下図のように起動する．"
 msgstr "RT System Editor should look like the following."
 
-#: ..\..\1.1_demo_imageprocessing.rst:85
+#: ../../1.1_demo_imageprocessing.rst:85
 msgid ""
 "左側のペインで 127.0.0.1 を選択し直上の右矢印をクリックすると，起動中の RT Component が同ペイン上に表示される．ここでは "
 "`DirectShowCamComp`，`FlipComp`，`CameraViewerComp` となるはず．"
@@ -133,7 +133,7 @@ msgstr ""
 "above will show the RT Components that are running. Here you should see "
 "`DirectShowCamComp`，`FlipComp`，`CameraViewerComp`."
 
-#: ..\..\1.1_demo_imageprocessing.rst:87
+#: ../../1.1_demo_imageprocessing.rst:87
 msgid ""
 "File --> Open New System Editor を選ぶと，`System Diagram` "
 "が真ん中のペインに開かれる．左側のペインから各 RTC を System Diagram にドラッグすると下図のように表示される．"
@@ -142,17 +142,17 @@ msgstr ""
 " pane at the center.Drag RTCs from left pane onto System Diagram and you'll "
 "see:"
 
-#: ..\..\1.1_demo_imageprocessing.rst:91
+#: ../../1.1_demo_imageprocessing.rst:91
 msgid "同ペイン上で各 RTC を接続．上に挙げた三つの RTC を左から接続する．"
 msgstr ""
 "Connect RTCs on the same pane. Connect them from left in the order listed "
 "above."
 
-#: ..\..\1.1_demo_imageprocessing.rst:93
+#: ../../1.1_demo_imageprocessing.rst:93
 msgid "同ペイン上で直上左にある \"ALL\" というアイコンをクリック，すべての RTC を activate (参考リンク 1_)"
 msgstr "Click \"ALL\" above, activate all RTCs."
 
-#: ..\..\1.1_demo_imageprocessing.rst:97
+#: ../../1.1_demo_imageprocessing.rst:97
 msgid ""
 "`CaptureImage` というウィンドウにカメラ画像が表示されれば入出力・接続が成功．同時に `DirectShowCamComp` "
 "のコマンドプロンプトにも `frame rate` が定期的に追加表示される．"
@@ -161,7 +161,7 @@ msgstr ""
 "`CaptureImage`. You'll also see constantly `frame rate` output on the "
 "command prompt `DirectShowCamComp`."
 
-#: ..\..\1.1_demo_imageprocessing.rst:101
+#: ../../1.1_demo_imageprocessing.rst:101
 msgid ""
 "`RTSystemEditor` 上で flip_mode の値を 1 --> 0 --> -1 と変える (Apply を忘れずに) "
 "とカメラ画像も変わることを確認できる．`flip_mode` の値と対応する挙動は次のようになる (画像引用元 2_)"
@@ -170,27 +170,27 @@ msgstr ""
 "forget to `Apply` button) then you see the image is converted. Behavior "
 "associated with `flip_mode` is as follows (image source 2_)"
 
-#: ..\..\1.1_demo_imageprocessing.rst:105
+#: ../../1.1_demo_imageprocessing.rst:105
 msgid "終了するには，次の手順で \"RTC を inactivate\" --> \"RTC 間のリンクを切り離し\" --> \"各 RTC を停止\" を行う．"
 msgstr "To end, \"inactivate RTC\" --> \"disconnect RTCs\" --> \"stop each RTC\""
 
-#: ..\..\1.1_demo_imageprocessing.rst:107
+#: ../../1.1_demo_imageprocessing.rst:107
 msgid "同ペイン上で直上左にある \"All Deactivate\" というアイコンをクリック"
 msgstr "Click \"All Deactivate\" at above left."
 
-#: ..\..\1.1_demo_imageprocessing.rst:108
+#: ../../1.1_demo_imageprocessing.rst:108
 msgid "で行ったのと逆を行う -- つまり，各接続線上で右クリックし\"切断\"を選択"
 msgstr ""
 "do the oposite -- that is, right-click on each connection line and "
 "\"Disconnect\""
 
-#: ..\..\1.1_demo_imageprocessing.rst:109
+#: ../../1.1_demo_imageprocessing.rst:109
 msgid "で起動されたコマンドプロンプト群を手動で終了．ただし `rtm-naming.bat` のそれは停止せずとも良い．"
 msgstr ""
 "manually end the command prompts. You can keep `rtm-naming.bat` running as "
 "mentioned earlier."
 
-#: ..\..\1.1_demo_imageprocessing.rst:111
+#: ../../1.1_demo_imageprocessing.rst:111
 msgid ""
 "ここで挙げた終了手順はやや煩雑ですが，御心配なく．次のチュートリアルからはこれらを一括して行うスクリプトを用意してあります．今回は初回なのでほぼすべてを手動で行い，`OpenRTM`"
 " のプログラム実行に必要な手順を体験して頂きました．"
@@ -200,15 +200,15 @@ msgstr ""
 "Just this time we've walked through behind-the-scenes of `OpenRTM` manually "
 "to get an idea."
 
-#: ..\..\1.1_demo_imageprocessing.rst:21
+#: ../../1.1_demo_imageprocessing.rst:21
 msgid "`RT System Editor` の初歩的な利用法"
 msgstr "Usage of `RT System Editor`"
 
-#: ..\..\1.1_demo_imageprocessing.rst:24
+#: ../../1.1_demo_imageprocessing.rst:24
 msgid "動作環境"
 msgstr "System Envirionment"
 
-#: ..\..\1.1_demo_imageprocessing.rst:45
+#: ../../1.1_demo_imageprocessing.rst:45
 #, fuzzy
 msgid ""
 "(上記方法でうまく行かなかった場合のみ以降実施) `Explorer` で `demo` フォルダを開き，`rtm-naming.bat` "
@@ -217,23 +217,23 @@ msgstr ""
 "(Only when the link above didn't work) Open `demo` folder on `Explorer` then"
 " start rtm-naming.bat_ by double clicking the file."
 
-#: ..\..\1.1_demo_imageprocessing.rst:123
+#: ../../1.1_demo_imageprocessing.rst:123
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<1.2_demo_mediaplaybyvoice.html>`__ |"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:125
+#: ../../1.1_demo_imageprocessing.rst:125
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:50
+#: ../../1.1_demo_imageprocessing.rst:50
 msgid "`cmd.exe` (Command prompt) が開きっぱなしになり，次のような文言が表示されれば成功．::"
 msgstr ""
 "Now `cmd.exe` (Command prompt) is kept open and you'll see following texts "
 "::"
 
-#: ..\..\1.1_demo_imageprocessing.rst:27
+#: ../../1.1_demo_imageprocessing.rst:27
 msgid "Internet Explorer (IE 以外のブラウザでは正常に動作しません)"
 msgstr "Internet Explorer (with browsers other than IE contents might not function as intended)"
 

--- a/doc/locale/en/LC_MESSAGES/1.2_demo_mediaplaybyvoice.po
+++ b/doc/locale/en/LC_MESSAGES/1.2_demo_mediaplaybyvoice.po
@@ -11,48 +11,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:1
+#: ../../1.2_demo_mediaplaybyvoice.rst:1
 msgid "**(デモ 2) 音声命令による動画再生 (OpenHRI)**"
 msgstr ""
 "`(Demo 2) Playing Movie via Voice (OpenHRI) "
 "<1.2_demo_mediaplaybyvoice.html>`_"
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:11
+#: ../../1.2_demo_mediaplaybyvoice.rst:11
 msgid "関連するチュートリアル"
 msgstr "Related Tutorials"
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:12
+#: ../../1.2_demo_mediaplaybyvoice.rst:12
 msgid "当ページでは最低限の操作方法のみ紹介します．`OpenHRI`, `SEATSAT` の詳細ては下記リンクを参照ください．"
 msgstr ""
 "You'll see very basic operation for `OpenHRI`, `SEATSAT`. See the following "
 "links for more."
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:14
+#: ../../1.2_demo_mediaplaybyvoice.rst:14
 msgid "当ページで紹介するデモの詳細．ページ内下方にある \"システムを起動する\"，\"動作例\" の章にしたがって作業を行ってください．[1_]"
 msgstr ""
 "Detail of the demo in this tutorial (in Japanese). Follow 'Running the "
 "system', 'Running example' at the lower side in the page [1_]"
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:16
+#: ../../1.2_demo_mediaplaybyvoice.rst:16
 msgid "なおソフトウェアは `./demo/0_SpeechDemo` にも梱包してあります．"
 msgstr "Same software is bundled in `./demo/0_SpeechDemo` in the USB."
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:17
+#: ../../1.2_demo_mediaplaybyvoice.rst:17
 msgid ""
 "ネット接続不可の場合のために同チュートリアル PDF を同梱しています ./doc/tutorial_openhri_mediaplay.pdf"
 msgstr "Same PDF files in bundled at ./doc/tutorial_openhri_mediaplay.pdf"
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:20
+#: ../../1.2_demo_mediaplaybyvoice.rst:20
 msgid "HowToRun"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:21
+#: ../../1.2_demo_mediaplaybyvoice.rst:21
 msgid "他のウィンドウの陰に表示されることがあるのでその場合は探して前面に移動．"
 msgstr ""
 "Multiple windows get opened and overlap with each other. Find appropriate "
 "one."
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:23
+#: ../../1.2_demo_mediaplaybyvoice.rst:23
 msgid ""
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\" "
 "の順に，下記リンクをクリックして実行．クリックして動作していなそうな場合，Explorer で \"./demo/0 SpeechDemo\" "
@@ -64,52 +64,52 @@ msgstr ""
 "them.(Since this demo uses Japanese language processor, we're not sure if "
 "this works in English though)"
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:33
+#: ../../1.2_demo_mediaplaybyvoice.rst:33
 msgid "\"tk\" と表示されるウィンドウを前面に移動．"
 msgstr "Move the window \"tk\" forward."
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:35
+#: ../../1.2_demo_mediaplaybyvoice.rst:35
 msgid "\"ビデオ\" と発話．\"video_list_mode\" と左肩に書かれた tk ウィンドウが表示される．"
 msgstr "Say \"Video\". A window whose title is \"video_list_mode\" appears."
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:37
+#: ../../1.2_demo_mediaplaybyvoice.rst:37
 msgid "\"リスト\" と発話．\"PlayList\" ウィンドウが表示される．"
 msgstr "Say \"list\" will open a window \"PlayList\"."
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:39
+#: ../../1.2_demo_mediaplaybyvoice.rst:39
 msgid "\"xばんめ\" (x = 1...5) と発話．\"PlayList\" ウィンドウ上でハイライト選択領域が変わる．"
 msgstr ""
 "(Not sure if this works in English though) Say \"x ban-me\" (x = 1...5) will"
 " pop up a window \"PlayList\" where highlighted item changes per the number "
 "you say."
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:41
+#: ../../1.2_demo_mediaplaybyvoice.rst:41
 msgid "\"再生\" と発話．\"Player\" ウィンドウで指定動画が再生される．"
 msgstr "Say \"Play\" will play the content on a window \"Player\""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:43
+#: ../../1.2_demo_mediaplaybyvoice.rst:43
 msgid "\"停止\" など試す．"
 msgstr "Say \"Stop\" and other commands that are available on the GUI."
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:45
+#: ../../1.2_demo_mediaplaybyvoice.rst:45
 msgid "終了時は，\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" の順に実行．"
 msgstr ""
 "When you finish the demo, click \"3_DeactivateRTC.bat\", "
 "\"4_DisconnectRTC.bat\", \"5_DemoExit.bat\" respectively"
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:55
+#: ../../1.2_demo_mediaplaybyvoice.rst:55
 msgid "RTC の deactivation は，コンポーネントがロードした実行時の必要リソースの量によって，時間がかかることがあります．"
 msgstr ""
 "Deactivation of RTCs might take awhile depending on the amount of the "
 "resource loaded by each component."
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:67
+#: ../../1.2_demo_mediaplaybyvoice.rst:67
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<1.3_choreonoid_createmotion.html>`__ |"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:69
+#: ../../1.2_demo_mediaplaybyvoice.rst:69
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 

--- a/doc/locale/en/LC_MESSAGES/1.3_choreonoid_createmotion.po
+++ b/doc/locale/en/LC_MESSAGES/1.3_choreonoid_createmotion.po
@@ -11,66 +11,66 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:1
+#: ../../1.3_choreonoid_createmotion.rst:1
 msgid "**(デモ 3) ロボットモーションの新規作成 (Choreonoid)**"
 msgstr ""
 "`(Demo 3) Create Robot Motions (Choreonoid) "
 "<1.3_choreonoid_createmotion.html>`_"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:11
+#: ../../1.3_choreonoid_createmotion.rst:11
 msgid "このページで体験すること"
 msgstr "What you'll experience"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:13
+#: ../../1.3_choreonoid_createmotion.rst:13
 msgid "`Choreonoid` 上で，既存のロボットモーションサンプルに自作のモーションを追加する．"
 msgstr "Add custom motion to an existing one on `Choreonoid`"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:16
+#: ../../1.3_choreonoid_createmotion.rst:16
 msgid "関連するチュートリアル"
 msgstr "Related Tutorials"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:17
+#: ../../1.3_choreonoid_createmotion.rst:17
 msgid "当ページでは最低限の操作方法のみ紹介します．`Choreonoid` に関する詳細は下記リンクを参照ください．"
 msgstr ""
 "You'll see very basic operation for `Choreonoid`. See the following links "
 "for more."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:19
+#: ../../1.3_choreonoid_createmotion.rst:19
 msgid "概要，詳細な使用法に関しては[1_]"
 msgstr "For detail and the usage more in detail, see [1_]"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:20
+#: ../../1.3_choreonoid_createmotion.rst:20
 msgid "モーション変更に関する詳細は[2_]"
 msgstr "About changing motion, see [2_]"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:23
+#: ../../1.3_choreonoid_createmotion.rst:23
 msgid "動作環境"
 msgstr "Required environment"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:24
+#: ../../1.3_choreonoid_createmotion.rst:24
 msgid "Windows 7／ 8"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:27
+#: ../../1.3_choreonoid_createmotion.rst:27
 msgid "実行方法"
 msgstr "Run the tutorial"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:28
+#: ../../1.3_choreonoid_createmotion.rst:28
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 "Your current directory is assumed to be the home of the USB unless "
 "specified."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:30
+#: ../../1.3_choreonoid_createmotion.rst:30
 msgid ".demo/BatchFiles/Choreonoid-GRobot.bat を実行．`Choreonoid` の GUI が起動する．"
 msgstr ""
 "Run .demo/BatchFiles/Choreonoid-GRobot.bat GUI for `Choreonoid` launches."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:36
+#: ../../1.3_choreonoid_createmotion.rst:36
 msgid "`Choreonoid` の GUI 上で，次の手順で既存モーションを読み込む．"
 msgstr "On `Choreonoid` GUI, read an existing motion by the following."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:38
+#: ../../1.3_choreonoid_createmotion.rst:38
 msgid ""
 "(英語版) \"File\" --> \"Open\" --> \"Pose Sequence\" --> Choose "
 "GR001SampleMotion1.pseq"
@@ -78,11 +78,11 @@ msgstr ""
 "(English ver software) \"File\" --> \"Open\" --> \"Pose Sequence\" --> "
 "Choose GR001SampleMotion1.pseq"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:40
+#: ../../1.3_choreonoid_createmotion.rst:40
 msgid "(日本語版) \"ファイル\" --> \"読み込み\" --> \"ポーズ列\" --> Choose GR001SampleMotion1.pseq"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:42
+#: ../../1.3_choreonoid_createmotion.rst:42
 msgid ""
 "もし上記手順でファイルが見えない場合，ファイルは以下に在る． "
 "`./demo/Choreonoid-1.1/share/projects/GR001SampleMotion1.pseq`"
@@ -90,14 +90,14 @@ msgstr ""
 "If the steps above don't let you see the file, it's "
 "there:`./demo/Choreonoid-1.1/share/projects/GR001SampleMotion1.pseq`"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:44
+#: ../../1.3_choreonoid_createmotion.rst:44
 msgid ""
 "選択したファイルに記述されるモーションが，`Choreonoid` 上の左側のペインに表示されるはずなのでそれをクリックして選択 (下図参照)．"
 msgstr ""
 "The motion in the selected file should appear on the pane on the left side "
 "of `Choreonoid`. Click it (see the image below)."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:48
+#: ../../1.3_choreonoid_createmotion.rst:48
 msgid ""
 "`Choreonoid` 上の \"PoseRoll\" ペイン上でカーソル (時間軸上に細い縦線で表示される) "
 "を，今回動作を追加する時点に移動．例えば既存のモーションの最後とする．"
@@ -106,37 +106,37 @@ msgstr ""
 " the timeline) twhere you'd like to add the motion. Say, at the end of the "
 "existing motion."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:50
+#: ../../1.3_choreonoid_createmotion.rst:50
 msgid "ロボットのペインを右クリックし，\"Edit Mode\"／\"編集モード\" に変更．これによりロボットのパーツを動かすことができるようになる．"
 msgstr ""
 "Right click on the robot's pane, select \"Edit Mode\". This allows moving "
 "robot parts."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:52
+#: ../../1.3_choreonoid_createmotion.rst:52
 msgid "ロボットのパーツを好きなように動かす．"
 msgstr "Move which ever part on the robots however you want :)"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:54
+#: ../../1.3_choreonoid_createmotion.rst:54
 msgid "\"PoseRoll\" ペインの \"Insert\"／\"現在姿勢の記憶\" をクリック．新たに追加された動作部分が赤く表示される．"
 msgstr ""
 "Click \"Insert\"／\"Current Motion\" on \"PoseRoll\" pane. The newly added "
 "porting will be highlighted in red."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:56
+#: ../../1.3_choreonoid_createmotion.rst:56
 msgid "保存を忘れずに．"
 msgstr "Do not forget to save."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:60
+#: ../../1.3_choreonoid_createmotion.rst:60
 msgid "ファイルを保存し，作業を終えたら，`Choreonoid` は終了して良い．"
 msgstr "It's your choice to close `Choreonoid` or not once the work is saved."
 
-#: ..\..\1.3_choreonoid_createmotion.rst:68
+#: ../../1.3_choreonoid_createmotion.rst:68
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<1.4_callmotion_byvoice.html>`__ |"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:70
+#: ../../1.3_choreonoid_createmotion.rst:70
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 

--- a/doc/locale/en/LC_MESSAGES/1.4_callmotion_byvoice.po
+++ b/doc/locale/en/LC_MESSAGES/1.4_callmotion_byvoice.po
@@ -11,69 +11,69 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.4_callmotion_byvoice.rst:1
+#: ../../1.4_callmotion_byvoice.rst:1
 msgid "**(デモ 4) 音声命令によるモーションの再生 (OpenHRI，Choreonoid)**"
 msgstr ""
 "`(Demo 4) Playing Motions via Voice (OpenHRI，Choreonoid) "
 "<1.4_callmotion_byvoice.html>`_"
 
-#: ..\..\1.4_callmotion_byvoice.rst:11
+#: ../../1.4_callmotion_byvoice.rst:11
 msgid "このページで体験すること"
 msgstr "What you'll experience"
 
-#: ..\..\1.4_callmotion_byvoice.rst:13
+#: ../../1.4_callmotion_byvoice.rst:13
 msgid "音声命令により `Choreonoid` 上のロボットのモーションを再生する．"
 msgstr "Play motion via voice on `Choreonoid`"
 
-#: ..\..\1.4_callmotion_byvoice.rst:16
+#: ../../1.4_callmotion_byvoice.rst:16
 msgid "関連するチュートリアル"
 msgstr "Related Tutorials"
 
-#: ..\..\1.4_callmotion_byvoice.rst:17
+#: ../../1.4_callmotion_byvoice.rst:17
 msgid "当ページでは最低限の操作方法のみ紹介します．`Choreonoid` や関連する `RTC` に関する詳細は下記リンクを参照ください．"
 msgstr ""
 "You'll see very basic operation for `Choreonoid` and related `RTC` in this "
 "tutorial. See the following links for more details."
 
-#: ..\..\1.4_callmotion_byvoice.rst:19
+#: ../../1.4_callmotion_byvoice.rst:19
 msgid "`Choreonoid` 上のロボットの腕を音声で上下する \"腕上げロボット\" サンプルについては[3_]"
 msgstr "Sample demo to operate robot\\'s arm via voice on `Choreonoid`[3_]"
 
-#: ..\..\1.4_callmotion_byvoice.rst:20
+#: ../../1.4_callmotion_byvoice.rst:20
 msgid ""
 "`Choreonoid` 上のロボットを `OpenRTM` 経由で操作するための RTC `RobotMotionRtc` に関しては[1_]"
 msgstr ""
 "`RobotMotionRtc` -- sample RTC to operate robot via `OpenRTM` on "
 "`Choreonoid`[1_]"
 
-#: ..\..\1.4_callmotion_byvoice.rst:21
+#: ../../1.4_callmotion_byvoice.rst:21
 msgid ""
 "今回用いるモデルで再現されるロボット `G-ROBOTS GR-001` を用いた `Choreonoid` のスタートアップガイドは[2_]"
 msgstr "Startup guide for `Choreonoid` by using `G-ROBOTS GR-001`[2_]"
 
-#: ..\..\1.4_callmotion_byvoice.rst:26
+#: ../../1.4_callmotion_byvoice.rst:26
 msgid "SystemEnvironment"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:27
+#: ../../1.4_callmotion_byvoice.rst:27
 msgid "Windows 7／ 8"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:28
+#: ../../1.4_callmotion_byvoice.rst:28
 msgid "マイクが Windows に認識されていること"
 msgstr "A microphone recognized by Windows"
 
-#: ..\..\1.4_callmotion_byvoice.rst:33
+#: ../../1.4_callmotion_byvoice.rst:33
 msgid "HowToRun"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:34
+#: ../../1.4_callmotion_byvoice.rst:34
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 "Your current directory is assumed to be the home of the USB unless "
 "specified."
 
-#: ..\..\1.4_callmotion_byvoice.rst:51
+#: ../../1.4_callmotion_byvoice.rst:51
 msgid ""
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\" "
 "の順に，下記リンクをクリックして実行．クリックして動作していなそうな場合，Explorer で \"./demo/0 SpeechDemo\" "
@@ -83,7 +83,7 @@ msgstr ""
 "respectively.If it doesn't work, run it manually in \"./demo/0 SpeechDemo\" "
 "from `Explorer`"
 
-#: ..\..\1.4_callmotion_byvoice.rst:61
+#: ../../1.4_callmotion_byvoice.rst:61
 msgid ""
 "(Optional) デバッグ用途として，`./demo/SampleWordLogger` 内の 0 から 2 までの `.bat` "
 "ファイルを実行しても良い．発話内容を記録する RTC である．"
@@ -91,7 +91,7 @@ msgstr ""
 "(Optional) To debug, you can run 0 to 2  `.bat` files in "
 "`./demo/SampleWordLogger` (an RTC that records what's spoken)."
 
-#: ..\..\1.4_callmotion_byvoice.rst:63
+#: ../../1.4_callmotion_byvoice.rst:63
 msgid ""
 "このときの RTC の連結状況を `RT System Editor` で表示 (SampleWordLogger "
 "を実行しなかった場合は，`SampleWordLogger0` RTC が無くなるのみ):"
@@ -100,45 +100,45 @@ msgstr ""
 "System Editor` (If you didn't run `SampleWordLogger`, you just don't see "
 "`SampleWordLogger0` RTC):"
 
-#: ..\..\1.4_callmotion_byvoice.rst:67
+#: ../../1.4_callmotion_byvoice.rst:67
 msgid "マイクに向かって \"みぎ あげて\" (スペースは0.5秒程度間を空ける) と発話．うまく認識されると，ロボットが右手を上げる．"
 msgstr ""
 "Say toward microphone \"migi a-ge-te\" (meaning: raise right hand, halt for "
 "about half an second at whitespace is better)"
 
-#: ..\..\1.4_callmotion_byvoice.rst:69
+#: ../../1.4_callmotion_byvoice.rst:69
 msgid "他に可能な組み合わせは"
 msgstr "Other possible combinations:"
 
-#: ..\..\1.4_callmotion_byvoice.rst:71
+#: ../../1.4_callmotion_byvoice.rst:71
 msgid "みぎ|ひだり"
 msgstr "right | left"
 
-#: ..\..\1.4_callmotion_byvoice.rst:73
+#: ../../1.4_callmotion_byvoice.rst:73
 msgid "`+`"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:75
+#: ../../1.4_callmotion_byvoice.rst:75
 msgid "あげて|さげて|あげない|さげない"
 msgstr "a-ge-te|sa-ge-te|a-ge-nai|sa-ge-nai"
 
-#: ..\..\1.4_callmotion_byvoice.rst:77
+#: ../../1.4_callmotion_byvoice.rst:77
 msgid "\"さいせい よろしく\" と発話．うまく認識されると，定義済の `SampleMotion1` に従ってロボットが動き出す．"
 msgstr ""
 "Say \"sai-sei yoro-shiku\" (meaning: let's play) will let the robot move "
 "according to `SampleMotion1`."
 
-#: ..\..\1.4_callmotion_byvoice.rst:79
+#: ../../1.4_callmotion_byvoice.rst:79
 msgid "終了時は，\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" の順に実行．"
 msgstr ""
 "Click \"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\", "
 "respectively."
 
-#: ..\..\1.4_callmotion_byvoice.rst:90
+#: ../../1.4_callmotion_byvoice.rst:90
 msgid "管理されているロボット状態"
 msgstr "Managed status of the robot"
 
-#: ..\..\1.4_callmotion_byvoice.rst:91
+#: ../../1.4_callmotion_byvoice.rst:91
 msgid ""
 "(次のチュートリアル[4_]のトピックですが) 当デモは `SEAT` "
 "というモジュールを用いて状態を管理しています．当デモが管理する状態は，`./demo/MotionByVoiceDemo/motion_cnoid.seatml`"
@@ -151,25 +151,25 @@ msgstr ""
 "combination of arms positions such as `both_down`, `both_up`, `left_up`, "
 "`right_up`."
 
-#: ..\..\1.4_callmotion_byvoice.rst:106
+#: ../../1.4_callmotion_byvoice.rst:106
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<1.5_modifystate_seatsat.html>`__ |"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:108
+#: ../../1.4_callmotion_byvoice.rst:108
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:37
+#: ../../1.4_callmotion_byvoice.rst:37
 msgid "Run Common Tools"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:38
+#: ../../1.4_callmotion_byvoice.rst:38
 msgid "In case they are not running."
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:49
+#: ../../1.4_callmotion_byvoice.rst:49
 msgid "Run This Tutorial"
 msgstr ""
 

--- a/doc/locale/en/LC_MESSAGES/1.5_modifystate_seatsat.po
+++ b/doc/locale/en/LC_MESSAGES/1.5_modifystate_seatsat.po
@@ -11,17 +11,17 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.5_modifystate_seatsat.rst:1
+#: ../../1.5_modifystate_seatsat.rst:1
 msgid "**(デモ 5) 状態遷移モデル変更による，新たなモーション実行 (SEATSAT)**"
 msgstr ""
 "`(Demo 5) Running New Motions Along with State Transion (SEATSAT) "
 "<1.5_modifystate_seatsat.html>`_"
 
-#: ..\..\1.5_modifystate_seatsat.rst:11
+#: ../../1.5_modifystate_seatsat.rst:11
 msgid "このページで体験すること"
 msgstr "What you'll experience"
 
-#: ..\..\1.5_modifystate_seatsat.rst:13
+#: ../../1.5_modifystate_seatsat.rst:13
 msgid ""
 "SEATSAT が管理するロボットの状態遷移に新たな状態を追加し，音声命令によりその状態へ遷移して `Choreonoid` "
 "上のロボットのモーションを再生する．"
@@ -29,11 +29,11 @@ msgstr ""
 "Add new state to `SEATSAT`-managed robot, traverse to that state by voice "
 "operation and play the motion on `Choreonoid`"
 
-#: ..\..\1.5_modifystate_seatsat.rst:16
+#: ../../1.5_modifystate_seatsat.rst:16
 msgid "関連するチュートリアル"
 msgstr "Related Tutorials"
 
-#: ..\..\1.5_modifystate_seatsat.rst:17
+#: ../../1.5_modifystate_seatsat.rst:17
 msgid ""
 "当ページでは最低限の操作方法のみ紹介します．`SEAT (Speech Event Action Transfer)` "
 "の一般的情報については下記リンクを参照ください．"
@@ -41,32 +41,32 @@ msgstr ""
 "You'll see very basic operation for `SEAT (Speech Event Action Transfer)` in"
 " this tutorial. See the following links for more details."
 
-#: ..\..\1.5_modifystate_seatsat.rst:19
+#: ../../1.5_modifystate_seatsat.rst:19
 msgid "`SEAT` 含む対話マネージャの書式について[1_]"
 msgstr "Format for the interactive state manager `SEAT`[1_]"
 
-#: ..\..\1.5_modifystate_seatsat.rst:22
+#: ../../1.5_modifystate_seatsat.rst:22
 msgid "動作環境"
 msgstr "SystemEnvironment"
 
-#: ..\..\1.5_modifystate_seatsat.rst:23
+#: ../../1.5_modifystate_seatsat.rst:23
 msgid ""
 "`前チュートリアルの動作環境 <1.4_callmotion_byvoice.html#SystemEnvironment>`__ を満たす．"
 msgstr ""
 "Satisfy `the environment defined in the previous tutorial "
 "<1.4_callmotion_byvoice.html#SystemEnvironment>`__ "
 
-#: ..\..\1.5_modifystate_seatsat.rst:26
+#: ../../1.5_modifystate_seatsat.rst:26
 msgid "実行方法"
 msgstr "HowToRun"
 
-#: ..\..\1.5_modifystate_seatsat.rst:27
+#: ../../1.5_modifystate_seatsat.rst:27
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 "Your current directory is assumed to be the home of the USB unless "
 "specified."
 
-#: ..\..\1.5_modifystate_seatsat.rst:33
+#: ../../1.5_modifystate_seatsat.rst:33
 msgid ""
 "まず，新たなロボットの状態を既に用意してあり，デモで体験しましょう．`前チュートリアル "
 "<1.4_callmotion_byvoice.html#SystemEnvironment>`__ を再び利用します．"
@@ -74,7 +74,7 @@ msgstr ""
 "First, let's run the robot status in the existing demo. Use the `previsous "
 "demo <1.4_callmotion_byvoice.html#SystemEnvironment>`__ again."
 
-#: ..\..\1.5_modifystate_seatsat.rst:35
+#: ../../1.5_modifystate_seatsat.rst:35
 msgid ""
 "`./demo/MotionByVoiceDemo` の \"0_StartDemo2.bat\" (前回使った \"0_StartDemo.bat\""
 " ではなく) を実行．"
@@ -82,11 +82,11 @@ msgstr ""
 "Run \"0_StartDemo2.bat\" in `./demo/MotionByVoiceDemo` (note that this isn't"
 "  \"0_StartDemo.bat\" we used previously)."
 
-#: ..\..\1.5_modifystate_seatsat.rst:43
+#: ../../1.5_modifystate_seatsat.rst:43
 msgid "\"1 ConnectRTC.bat\", \"2 ActivateRTC.bat\" を実行．"
 msgstr "Run \"1 ConnectRTC.bat\", \"2 ActivateRTC.bat\", respectively"
 
-#: ..\..\1.5_modifystate_seatsat.rst:52
+#: ../../1.5_modifystate_seatsat.rst:52
 msgid ""
 "\"さいせい よろしく\" と発話．前回と違い今回は，ロボットはおじぎをして手を下げる．なお `Choreonoid` "
 "画面上では見えないが，`SEAT` の管理するロボットの状態は `dance_ready` という新たな状態に移っている．"
@@ -95,13 +95,13 @@ msgstr ""
 "down and put arms down. By the way it's not visible on `Choreonoid`, but the"
 " state managed by `SEAT` is now `dance_ready`."
 
-#: ..\..\1.5_modifystate_seatsat.rst:54
+#: ../../1.5_modifystate_seatsat.rst:54
 msgid "\"さいせい よろしく\" コマンドは，既存のどのロボット状態からでも有効です; (例．右手だけ上がった状態)"
 msgstr ""
 "Command \"sa-sei yoro-shiku\" is valid from any robot state (eg. when only "
 "the right hand is up)."
 
-#: ..\..\1.5_modifystate_seatsat.rst:56
+#: ../../1.5_modifystate_seatsat.rst:56
 msgid ""
 "\"あくしょん よろしく\" と発話．ロボットは前回のチュートリアルで見せたのと同じダンスをする．その後 `both_down` 状態 (初期の状態) "
 "に戻る．"
@@ -109,40 +109,45 @@ msgstr ""
 "Say \"action yoro-shiku\". Robot starts the same dance from the previous "
 "tutorial, then goes back to the initial `both_down` state."
 
-#: ..\..\1.5_modifystate_seatsat.rst:58
+#: ../../1.5_modifystate_seatsat.rst:58
 msgid "終了時は，\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" の順に実行．"
 msgstr ""
 "Click \"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\", "
 "respectively."
 
-#: ..\..\1.5_modifystate_seatsat.rst:69
+#: ../../1.5_modifystate_seatsat.rst:69
 msgid "新規状態の追加方法"
 msgstr "Add new state"
 
-#: ..\..\1.5_modifystate_seatsat.rst:70
+#: ../../1.5_modifystate_seatsat.rst:70
 msgid "状態を追加するために今回追加したのは次の箇所::"
 msgstr "This portion represents the added state::"
 
-#: ..\..\1.5_modifystate_seatsat.rst:92
+#: ../../1.5_modifystate_seatsat.rst:92
 msgid "また，`あくしょん` という新たな語を音声認識させるために，`Julius` の設定ファイルも次のように更新::"
 msgstr ""
 "Also, edit the config file in `Julius` to enable a new term `action` in the "
 "voice recognition::"
 
-#: ..\..\1.5_modifystate_seatsat.rst:116
+#: ../../1.5_modifystate_seatsat.rst:116
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:31
+#: ../../1.5_modifystate_seatsat.rst:31
 msgid ""
 "For starting necessary services, quickly go [run-common-tools_] and come "
 "back."
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:114
+#: ../../1.5_modifystate_seatsat.rst:114
 msgid ""
-"Go back to `index <top.html>`__ | Go to `next <1.6_scararobot_control>`__ |"
+"Go back to `index <top.html>`__ | Go to `next "
+"<1.6_scararobot_control.html>`__ |"
 msgstr ""
+
+#~ msgid ""
+#~ "Go back to `index <top.html>`__ | Go to `next <1.6_scararobot_control>`__ |"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Go back to `index <top.html>`__ | Go to `next <2.1_samplewordlogger.html>`__"

--- a/doc/locale/en/LC_MESSAGES/1.6_scararobot_control.po
+++ b/doc/locale/en/LC_MESSAGES/1.6_scararobot_control.po
@@ -11,54 +11,54 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.6_scararobot_control.rst:1
+#: ../../1.6_scararobot_control.rst:1
 msgid "**(デモ 6) アカデミック スカラロボットの制御 **"
 msgstr "**(Demo 6) Academic SCARA Robot Control **"
 
-#: ..\..\1.6_scararobot_control.rst:11
+#: ../../1.6_scararobot_control.rst:11
 msgid "Introduction"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:14
+#: ../../1.6_scararobot_control.rst:14
 msgid "このページで体験すること"
 msgstr "What you'll experience"
 
-#: ..\..\1.6_scararobot_control.rst:15
+#: ../../1.6_scararobot_control.rst:15
 msgid "アカデミック スカラロボットの制御　ver.1.1"
 msgstr "Academic SCARA Robot Control (ver.1.1)"
 
-#: ..\..\1.6_scararobot_control.rst:18
+#: ../../1.6_scararobot_control.rst:18
 msgid "動作環境"
 msgstr "System Environment"
 
-#: ..\..\1.6_scararobot_control.rst:21
+#: ../../1.6_scararobot_control.rst:21
 msgid "ヴイストン株式会社製 アカデミック スカラロボット（VS-ASR） [1_]"
 msgstr "Academic SCARA Robot (VS-ASR) made by VSTONE Co., Ltd. [1_]"
 
-#: ..\..\1.6_scararobot_control.rst:24
+#: ../../1.6_scararobot_control.rst:24
 msgid "実行方法"
 msgstr "Run the tutorial"
 
-#: ..\..\1.6_scararobot_control.rst:25
+#: ../../1.6_scararobot_control.rst:25
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 "Your current directory is assumed to be the home of the USB unless "
 "specified."
 
-#: ..\..\1.6_scararobot_control.rst:28
+#: ../../1.6_scararobot_control.rst:28
 msgid "nameserver 起動 (全チュートリアル共通)"
 msgstr "Start CORBA nameserver (common throughout all tutorials)"
 
-#: ..\..\1.6_scararobot_control.rst:29
+#: ../../1.6_scararobot_control.rst:29
 msgid "基本的に `OpenRTM` の `nameserver` は一度起動すると，起動したままでもすべてのチュートリアルは動作すると思われます．"
 msgstr ""
 "Once you start, nameserver can be kept running throught all tutorials."
 
-#: ..\..\1.6_scararobot_control.rst:31
+#: ../../1.6_scararobot_control.rst:31
 msgid "次のリンクをクリックして `nameserver` を起動．"
 msgstr "Click the link to start nameserver."
 
-#: ..\..\1.6_scararobot_control.rst:39
+#: ../../1.6_scararobot_control.rst:39
 msgid ""
 "（上記方法でうまく行かなかった場合のみ以降実施） `Explorer` で `demo` フォルダを開き，`rtm-naming.bat` "
 "をダブルクリックして実行．"
@@ -66,43 +66,43 @@ msgstr ""
 "(Only when the link above didn't work) Open `demo` folder on `Explorer` then"
 " start rtm-naming.bat_ by double clicking the file."
 
-#: ..\..\1.6_scararobot_control.rst:41
+#: ../../1.6_scararobot_control.rst:41
 msgid "`cmd.exe` (Command prompt) が開きっぱなしになり，次のような文言が表示されれば成功．::"
 msgstr ""
 "Now `cmd.exe` (Command prompt) is kept open and you'll see following texts "
 "::"
 
-#: ..\..\1.6_scararobot_control.rst:47
+#: ../../1.6_scararobot_control.rst:47
 msgid "上記手順で `cmd.exe` が消えてしまう場合は，`nameserver` がうまく起動していないので次の手順で原因を発見："
 msgstr ""
 "If `cmd.exe` doesn't stay, you're somehow failing to run `nameserver` so try"
 " to find the cause by the following:"
 
-#: ..\..\1.6_scararobot_control.rst:49
+#: ../../1.6_scararobot_control.rst:49
 msgid "3.1) `Explorer` 上で，USB のドライブ名を確認 (D/E/F etc. ここでは `F` と仮定)"
 msgstr ""
 "3.1) On `Explorer`, check the drive letter of the tutorial USB (usually "
 "either D/E/F. Here we assume as `F`)"
 
-#: ..\..\1.6_scararobot_control.rst:51
+#: ../../1.6_scararobot_control.rst:51
 msgid "3.2) `cmd.exe` を手動起動 (Win 7: [2_], Win 8: [3_])"
 msgstr "2.2) Manually start `cmd.exe` (Win 7: [2_], Win 8: [3_])"
 
-#: ..\..\1.6_scararobot_control.rst:53
+#: ../../1.6_scararobot_control.rst:53
 msgid "3.3) 以下コマンドでフォルダ移動・コマンド実行::"
 msgstr "3.3) Run the following commands to move to the folder::"
 
-#: ..\..\1.6_scararobot_control.rst:59
+#: ../../1.6_scararobot_control.rst:59
 msgid ""
 "エラー等発生していればここで表示されるのでその内容を診断．`OpenRTM` の `nameserver` の問題は WEB "
 "で検索して対処してみてください．"
 msgstr "Diagnose errors. Many errors with `CORBA` can be found on the WEB."
 
-#: ..\..\1.6_scararobot_control.rst:62
+#: ../../1.6_scararobot_control.rst:62
 msgid "チュートリアルのプログラム実行"
 msgstr "Run programs in the tutorial"
 
-#: ..\..\1.6_scararobot_control.rst:64
+#: ../../1.6_scararobot_control.rst:64
 msgid ""
 "次のリンクをクリックして `./demo/ScaraRobotDemo/0_StartDemo.bat` を実行する．起動できない場合は，手動で "
 "`Explorer` から実行する．"
@@ -110,174 +110,174 @@ msgstr ""
 "Run `./demo/OpencvRtmDemo/0_StartDemo.bat` by clicking on the link below. If"
 " it doesn't work, run it manually from `Explorer`."
 
-#: ..\..\1.6_scararobot_control.rst:70
+#: ../../1.6_scararobot_control.rst:70
 msgid "なお，スカラロボットの座標系は図1に示す通りである．"
 msgstr "The coordinate system of the SCARA robot is shown in Fig. 1."
 
-#: ..\..\1.6_scararobot_control.rst:74
+#: ../../1.6_scararobot_control.rst:74
 msgid "図1　スカラロボットの座標系"
 msgstr "Fig. 1  Coordinate system of SCARA robot"
 
-#: ..\..\1.6_scararobot_control.rst:76
+#: ../../1.6_scararobot_control.rst:76
 msgid "次のリンクをクリックして `./misc/VstoneScaraRobotRTC/Sample.csv` を編集する．"
 msgstr ""
 "Edit `./misc/VstoneScaraRobotRTC/Sample.csv` by clicking on the link below."
 
-#: ..\..\1.6_scararobot_control.rst:82
+#: ../../1.6_scararobot_control.rst:82
 msgid "なお，スカラロボットで使用可能なコマンドは表1に示す通りである．"
 msgstr "The enable commands in the SCARA robot is shown in Table 1."
 
-#: ..\..\1.6_scararobot_control.rst:84
+#: ../../1.6_scararobot_control.rst:84
 msgid "表1　スカラロボットで使用可能なコマンド"
 msgstr "Table 1  Commads in SCARA robots"
 
-#: ..\..\1.6_scararobot_control.rst:87
+#: ../../1.6_scararobot_control.rst:87
 msgid "No."
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:87
+#: ../../1.6_scararobot_control.rst:87
 msgid "コマンド"
 msgstr "Commands"
 
-#: ..\..\1.6_scararobot_control.rst:87
+#: ../../1.6_scararobot_control.rst:87
 msgid "書式"
 msgstr "Formats"
 
-#: ..\..\1.6_scararobot_control.rst:87 ..\..\1.6_scararobot_control.rst:133
+#: ../../1.6_scararobot_control.rst:87 ../../1.6_scararobot_control.rst:133
 msgid "説明"
 msgstr "Details"
 
-#: ..\..\1.6_scararobot_control.rst:89
+#: ../../1.6_scararobot_control.rst:89
 msgid "1"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:89 ..\..\1.6_scararobot_control.rst:89
+#: ../../1.6_scararobot_control.rst:89 ../../1.6_scararobot_control.rst:89
 msgid "SERVO_OFF"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:89
+#: ../../1.6_scararobot_control.rst:89
 msgid "全軸サーボをOFFにする．"
 msgstr "Turn off all servomotors."
 
-#: ..\..\1.6_scararobot_control.rst:91
+#: ../../1.6_scararobot_control.rst:91
 msgid "2"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:91 ..\..\1.6_scararobot_control.rst:91
+#: ../../1.6_scararobot_control.rst:91 ../../1.6_scararobot_control.rst:91
 msgid "SERVO_ON"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:91
+#: ../../1.6_scararobot_control.rst:91
 msgid "全軸サーボをONにする．"
 msgstr "Trun on all servomotors."
 
-#: ..\..\1.6_scararobot_control.rst:93
+#: ../../1.6_scararobot_control.rst:93
 msgid "3"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:93 ..\..\1.6_scararobot_control.rst:93
+#: ../../1.6_scararobot_control.rst:93 ../../1.6_scararobot_control.rst:93
 msgid "HAND_CLOSE"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:93
+#: ../../1.6_scararobot_control.rst:93
 msgid "ハンドを完全に閉じる．"
 msgstr "Completely close hands."
 
-#: ..\..\1.6_scararobot_control.rst:95
+#: ../../1.6_scararobot_control.rst:95
 msgid "4"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:95 ..\..\1.6_scararobot_control.rst:95
+#: ../../1.6_scararobot_control.rst:95 ../../1.6_scararobot_control.rst:95
 msgid "HAND_OPEN"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:95
+#: ../../1.6_scararobot_control.rst:95
 msgid "ハンドを完全に開く．"
 msgstr "Completely open hands."
 
-#: ..\..\1.6_scararobot_control.rst:97
+#: ../../1.6_scararobot_control.rst:97
 msgid "5"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:97
+#: ../../1.6_scararobot_control.rst:97
 msgid "HAND_MOV"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:97
+#: ../../1.6_scararobot_control.rst:97
 msgid "HAND_MOV，Rate（単位：Rate [%]）"
 msgstr "HAND_MOV, Rate (Measure: Rate [%])"
 
-#: ..\..\1.6_scararobot_control.rst:97
+#: ../../1.6_scararobot_control.rst:97
 msgid "ハンドを指定した開閉角度に動作させる．"
 msgstr "Open/close the finger to the specified width."
 
-#: ..\..\1.6_scararobot_control.rst:99
+#: ../../1.6_scararobot_control.rst:99
 msgid "6"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:99
+#: ../../1.6_scararobot_control.rst:99
 msgid "CMVS"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:99
+#: ../../1.6_scararobot_control.rst:99
 msgid "CMVS，X，Y，Z，Rz（単位：X，Y，Z [m]，Rz [rad]）"
 msgstr "CMVS, X, Y, Z, Rz (Measure: X, Y, Z [m], Rz [rad])"
 
-#: ..\..\1.6_scararobot_control.rst:99
+#: ../../1.6_scararobot_control.rst:99
 msgid "ロボット座標系の絶対値で指定された目標位置に対し，直交空間における直線補間で動作させる．"
 msgstr ""
 "Move hands using the linear interpolation in the orthogonal space up to the "
 "target position in the robot coordinate system"
 
-#: ..\..\1.6_scararobot_control.rst:101
+#: ../../1.6_scararobot_control.rst:101
 msgid "7"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:101
+#: ../../1.6_scararobot_control.rst:101
 msgid "CMOV"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:101
+#: ../../1.6_scararobot_control.rst:101
 msgid "CMOV，X，Y，Z，Rz（単位：X，Y，Z [m]，Rz [rad]）"
 msgstr "CMOV, X, Y, Z, Rz (Measure: X, Y, Z [m], Rz [rad])"
 
-#: ..\..\1.6_scararobot_control.rst:101
+#: ../../1.6_scararobot_control.rst:101
 msgid "ロボット座標系の絶対値で指定された目標位置に対し，関節空間における直線補間で動作させる．"
 msgstr ""
 "Move hands using the linear interpolation in the joint space up to the "
 "target position in the robot coordinate system"
 
-#: ..\..\1.6_scararobot_control.rst:103
+#: ../../1.6_scararobot_control.rst:103
 msgid "8"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:103
+#: ../../1.6_scararobot_control.rst:103
 msgid "JMOV"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:103
+#: ../../1.6_scararobot_control.rst:103
 msgid "JMOV，J1，J2，J3，J4（単位：J1，J2，J4 [rad]，J3 [m]）"
 msgstr "JMOV, J1, J2, J3, J4 (Measure: J1, J2, J4 [rad], J3 [m])"
 
-#: ..\..\1.6_scararobot_control.rst:103
+#: ../../1.6_scararobot_control.rst:103
 msgid "関節座標系の絶対値で指定された目標位置に対し，関節空間における直線補間で動作させる．"
 msgstr ""
 "Move hands using the linear interpolation in the joint space up to the "
 "target position in the joint coordinate system"
 
-#: ..\..\1.6_scararobot_control.rst:106
+#: ../../1.6_scararobot_control.rst:106
 msgid "次のリンクをクリックして `./demo/RTSE.bat` を実行する．"
 msgstr "Run `./demo/RTSE.bat` by clicking on the link below."
 
-#: ..\..\1.6_scararobot_control.rst:112
+#: ../../1.6_scararobot_control.rst:112
 msgid "RT System Editor が図2のように起動する．"
 msgstr "RT System Editor should look like Fig. 2."
 
-#: ..\..\1.6_scararobot_control.rst:116
+#: ../../1.6_scararobot_control.rst:116
 msgid "図2　RT System Editor"
 msgstr "Fig. 2  RT System Editor"
 
-#: ..\..\1.6_scararobot_control.rst:118
+#: ../../1.6_scararobot_control.rst:118
 msgid ""
 "左側のペインで 127.0.0.1 を選択し，直上の右矢印をクリックすると，起動中の RT Component が同ペイン上に表示される．ここでは "
 "`ScaraRobotControlRTC` ， `VS_ASR_RTC` となるはず．"
@@ -286,7 +286,7 @@ msgstr ""
 "above will show the RT Components that are running. Here you should see "
 "`ScaraRobotControlRTC`, `VS_ASR_RTC`."
 
-#: ..\..\1.6_scararobot_control.rst:120
+#: ../../1.6_scararobot_control.rst:120
 msgid ""
 "File --> Open New System Editor を選ぶと， `System Diagram` "
 "が真ん中のペインに開かれる．左側のペインから各 RTC を System Diagram にドラッグすると図3のように表示される．"
@@ -295,17 +295,17 @@ msgstr ""
 " pane at the center. Drag RTCs from left pane onto System Diagram and you'll"
 " see:"
 
-#: ..\..\1.6_scararobot_control.rst:124
+#: ../../1.6_scararobot_control.rst:124
 msgid "図3　RTC を配置した RT System Editor"
 msgstr "Fig. 3  RTC onto the RT System Editor"
 
-#: ..\..\1.6_scararobot_control.rst:126
+#: ../../1.6_scararobot_control.rst:126
 msgid "同ペイン上で各 RTC を接続する．上に挙げた2つの RTC を接続する．"
 msgstr ""
 "Connect RTCs on the same pane. Connect them from left in the order listed "
 "above."
 
-#: ..\..\1.6_scararobot_control.rst:128
+#: ../../1.6_scararobot_control.rst:128
 msgid ""
 "同ペイン内の`ScaraRobotControlRTC`をクリックし，直下にある“Configuration” というタブ内の "
 "Configuration 値を編集する．各 Configuration 値の詳細は表2に示す通りである．"
@@ -313,142 +313,142 @@ msgstr ""
 "Click `ScaraRobotControlRTC` on the same pane. Edit configuration values in "
 "the configuration tab just below the pain."
 
-#: ..\..\1.6_scararobot_control.rst:130
+#: ../../1.6_scararobot_control.rst:130
 msgid "表2　ScaraRobotControlRTCのコンフィギュレーション"
 msgstr "Table 2  Configuration of ScaraRobotControlRTC"
 
-#: ..\..\1.6_scararobot_control.rst:133
+#: ../../1.6_scararobot_control.rst:133
 msgid "名前"
 msgstr "Names"
 
-#: ..\..\1.6_scararobot_control.rst:133
+#: ../../1.6_scararobot_control.rst:133
 msgid "デフォルト値"
 msgstr "Default values"
 
-#: ..\..\1.6_scararobot_control.rst:135
+#: ../../1.6_scararobot_control.rst:135
 msgid "BaseOffsetX"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:135 ..\..\1.6_scararobot_control.rst:137
+#: ../../1.6_scararobot_control.rst:135 ../../1.6_scararobot_control.rst:137
 msgid "0.0"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:135
+#: ../../1.6_scararobot_control.rst:135
 msgid "ベースオフセットのX軸方向の値を[m]で指定．"
 msgstr "Specify BaseOffset in X axial direction."
 
-#: ..\..\1.6_scararobot_control.rst:137
+#: ../../1.6_scararobot_control.rst:137
 msgid "BaseOffsetY"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:137
+#: ../../1.6_scararobot_control.rst:137
 msgid "ベースオフセットのY軸方向の値を[m]で指定．"
 msgstr "Specify BaseOffset in Y axial direction."
 
-#: ..\..\1.6_scararobot_control.rst:139
+#: ../../1.6_scararobot_control.rst:139
 msgid "FilePass"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:139
+#: ../../1.6_scararobot_control.rst:139
 msgid "Sample.csv"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:139
+#: ../../1.6_scararobot_control.rst:139
 msgid "読み込むcsvファイルが保存されている場所までのパスを指定．"
 msgstr "Specify the path where the csv file exists."
 
-#: ..\..\1.6_scararobot_control.rst:141
+#: ../../1.6_scararobot_control.rst:141
 msgid "Speed"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:141
+#: ../../1.6_scararobot_control.rst:141
 msgid "30"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:141
+#: ../../1.6_scararobot_control.rst:141
 msgid "ロボットの動作速度を1[%]～100[%]の整数値で指定．"
 msgstr ""
 "Specify the working speed of the robot from 1 to 100[%] in an integer value."
 
-#: ..\..\1.6_scararobot_control.rst:144
+#: ../../1.6_scararobot_control.rst:144
 msgid "同ペイン上で直上左にある“ALL”というアイコンをクリック，すべての RTC を activate (参考リンク 1_)．"
 msgstr "Click \"ALL\" above, activate all RTCs."
 
-#: ..\..\1.6_scararobot_control.rst:148
+#: ../../1.6_scararobot_control.rst:148
 msgid "図4　RT System Editor における RTC の Activate"
 msgstr "Fig. 4  Activate RTC in RTC System Editor"
 
-#: ..\..\1.6_scararobot_control.rst:150
+#: ../../1.6_scararobot_control.rst:150
 msgid ""
 "手順5～8を一括して行うスクリプト `./demo/ScaraRobotDemo/8_ConnectRTC.bat` は以下に用意してあります．"
 msgstr ""
 "Script that runs step 5 to 8 in groups is provied by clicking on the link "
 "below."
 
-#: ..\..\1.6_scararobot_control.rst:156
+#: ../../1.6_scararobot_control.rst:156
 msgid "`ScaraRobotControlRTC` のコマンドプロンプトで `s` キーを入力すると，ロボットが動作を開始する．"
 msgstr ""
 "Input `s` by keyboard in the command prompt of `ScaraRobotControlRTC`, then "
 "the robot starts operations."
 
-#: ..\..\1.6_scararobot_control.rst:160
+#: ../../1.6_scararobot_control.rst:160
 msgid "図5 ScaraRobotControlRTC"
 msgstr "Fig. 5  Scara Robot Control RTC"
 
-#: ..\..\1.6_scararobot_control.rst:162
+#: ../../1.6_scararobot_control.rst:162
 msgid ""
 "`VS_ASR_RTC0` のコマンドプロンプトには，実行しているコマンドのステータスが表示されます（例：関節角リミットオーバーでエラー停止した状態）．"
 msgstr ""
 "Command prompt of `ScaraRobotControlRTC` shows the status of executing "
 "commands. (For example, the robot go over the angle limit, and you'll see:)"
 
-#: ..\..\1.6_scararobot_control.rst:166
+#: ../../1.6_scararobot_control.rst:166
 msgid "図6　関節角リミットオーバーでエラー停止した状態"
 msgstr "Fig. 6  The robot went over the angle limit, then has stopped"
 
-#: ..\..\1.6_scararobot_control.rst:168
+#: ../../1.6_scararobot_control.rst:168
 msgid "終了するには，次の手順で \"RTC を inactivate\" --> \"RTC 間のリンクを切り離し\" --> \"各 RTC を停止\" を行う．"
 msgstr "To end, \"inactivate RTC\" --> \"disconnect RTCs\" --> \"stop each RTC\""
 
-#: ..\..\1.6_scararobot_control.rst:170
+#: ../../1.6_scararobot_control.rst:170
 msgid "同ペイン上で直上左にある \"All Deactivate\" というアイコンをクリック"
 msgstr "Click \"All Deactivate\" at above left."
 
-#: ..\..\1.6_scararobot_control.rst:171
+#: ../../1.6_scararobot_control.rst:171
 msgid "手順6で行ったのと逆を行う．つまり，各接続線上で右クリックし\"切断\"を選択．"
 msgstr ""
 "Do the oposite. That is, right-click on each connection line and "
 "\"Disconnect\""
 
-#: ..\..\1.6_scararobot_control.rst:172
+#: ../../1.6_scararobot_control.rst:172
 msgid "手順1で起動したコマンドプロンプト群を手動で終了．ただし `rtm-naming.bat` のそれは停止せずとも良い．"
 msgstr ""
 "manually end the command prompts. You can keep `rtm-naming.bat` running as "
 "mentioned earlier."
 
-#: ..\..\1.6_scararobot_control.rst:174
+#: ../../1.6_scararobot_control.rst:174
 msgid "※手順11を一括して行うスクリプトは以下に用意してある．"
 msgstr ""
 "Note: Script that runs step 11 in groups is provied by clicking on the link "
 "below."
 
-#: ..\..\1.6_scararobot_control.rst:180
+#: ../../1.6_scararobot_control.rst:180
 msgid "関節角リミットオーバーでエラー停止した状態からの復帰方法"
 msgstr ""
-"Method for recovery when the robot went over the angle limit or get "
-"illegal command, then has stopped."
+"Method for recovery when the robot went over the angle limit or get illegal "
+"command, then has stopped."
 
-#: ..\..\1.6_scararobot_control.rst:182
+#: ../../1.6_scararobot_control.rst:182
 msgid "12.1) 関節角リミットオーバーでエラーを出力して停止している状態である．"
 msgstr ""
 "12.1) The robot went over the angle limit, read out the error, then has "
 "stopped. "
 
-#: ..\..\1.6_scararobot_control.rst:186
+#: ../../1.6_scararobot_control.rst:186
 msgid "図7　復帰方法 1"
 msgstr "Fig. 7  1st step of method for recovery"
 
-#: ..\..\1.6_scararobot_control.rst:188
+#: ../../1.6_scararobot_control.rst:188
 msgid ""
 "12.2) "
 "まず，ScaraRobotControlRTCの上にカーソルを持っていき，右クリックでプルダウンメニューを出し，その中のResetを選択する．"
@@ -456,19 +456,19 @@ msgstr ""
 "12.2) Move the cursor to the `ScaraRobotControlRTC`, then right click to "
 "open pull-down menu and choose Reset."
 
-#: ..\..\1.6_scararobot_control.rst:192
+#: ../../1.6_scararobot_control.rst:192
 msgid "図8　復帰方法 2"
 msgstr "Fig. 8  2nd step of method for recovery"
 
-#: ..\..\1.6_scararobot_control.rst:194
+#: ../../1.6_scararobot_control.rst:194
 msgid "12.3) Reset後は下図のような状態になる．"
 msgstr "12.3) After reset, you'll see:"
 
-#: ..\..\1.6_scararobot_control.rst:198
+#: ../../1.6_scararobot_control.rst:198
 msgid "図9　復帰方法 3"
 msgstr "Fig. 9  3rd step of method for recovery"
 
-#: ..\..\1.6_scararobot_control.rst:200
+#: ../../1.6_scararobot_control.rst:200
 msgid ""
 "12.4) RTC 以外の System Diagram 上で右クリックによりプルダウンメニューを出し，All Activate "
 "を選択する．これで最初の状態に戻る．"
@@ -476,25 +476,25 @@ msgstr ""
 "12.4) Right click on the space where no RTCs in system diagram to open pull-"
 "down menu and choose All Activate. This returns to the initial state."
 
-#: ..\..\1.6_scararobot_control.rst:204
+#: ../../1.6_scararobot_control.rst:204
 msgid "図10　復帰方法 4"
 msgstr "Fig. 10 4th step of method for recovery"
 
-#: ..\..\1.6_scararobot_control.rst:214
+#: ../../1.6_scararobot_control.rst:214
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next <2.1_samplewordlogger.html>`__"
 " |"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:216
+#: ../../1.6_scararobot_control.rst:216
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:19
+#: ../../1.6_scararobot_control.rst:19
 msgid "Windows 7 / 8"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:20
+#: ../../1.6_scararobot_control.rst:20
 msgid "Internet Explorer (IE) 8 / 10"
 msgstr ""
 

--- a/doc/locale/en/LC_MESSAGES/2.1_samplewordlogger.po
+++ b/doc/locale/en/LC_MESSAGES/2.1_samplewordlogger.po
@@ -11,21 +11,21 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\2.1_samplewordlogger.rst:1
+#: ../../2.1_samplewordlogger.rst:1
 msgid "**(RTC 作成 1) 音声キーワードロガー RTC の開発**"
 msgstr ""
 "`Logger RTC that Saves the Voice-recognized Time-stamped Keywords "
 "<2.1_samplewordlogger.html>`_"
 
-#: ..\..\2.1_samplewordlogger.rst:12
+#: ../../2.1_samplewordlogger.rst:12
 msgid "Introduction"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:15
+#: ../../2.1_samplewordlogger.rst:15
 msgid "このページで体験すること"
 msgstr "What you'll experience"
 
-#: ..\..\2.1_samplewordlogger.rst:17
+#: ../../2.1_samplewordlogger.rst:17
 msgid ""
 "`OpenHRI` の RTC と接続することで，音声認識されたキーワードのログを取得し，時刻とともにファイルに保存する "
 "`SampleWordLogger RTC` の開発"
@@ -33,11 +33,11 @@ msgstr ""
 "`Develop a Logger RTC that connects an RTC in `OpenHRI`and saves the voice-"
 "recognized, timestamped Keywords."
 
-#: ..\..\2.1_samplewordlogger.rst:20
+#: ../../2.1_samplewordlogger.rst:20
 msgid "関連するチュートリアル"
 msgstr "Related Tutorials"
 
-#: ..\..\2.1_samplewordlogger.rst:21
+#: ../../2.1_samplewordlogger.rst:21
 msgid ""
 "`RTC` 作成の一般的作業の詳細は SampleWordLogger コンポーネントのチュートリアル[1_]に記述があります．特に `Eclipse`"
 " 上での GUI を利用した開発が説明されています． - "
@@ -47,39 +47,39 @@ msgstr ""
 "though) in `SampleWordLogger` RTC tutorial[1_], where especially the usage "
 "of graphical tool on `Eclipse` is included."
 
-#: ..\..\2.1_samplewordlogger.rst:25
+#: ../../2.1_samplewordlogger.rst:25
 msgid "SystemEnvironment"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:26
+#: ../../2.1_samplewordlogger.rst:26
 msgid "Windows 7 / 8"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:27
+#: ../../2.1_samplewordlogger.rst:27
 msgid "Visual C++ 2010 (English [3_], Japanese [4_])"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:28
+#: ../../2.1_samplewordlogger.rst:28
 msgid ""
 "`CMake` 2.8 (インストーラが同梱されています ./misc/installer/cmake-2.8.8-win32-x86.exe)"
 msgstr ""
 "`CMake` 2.8 (its installer is bundled in "
 "./misc/installer/cmake-2.8.8-win32-x86.exe)"
 
-#: ..\..\2.1_samplewordlogger.rst:29
+#: ../../2.1_samplewordlogger.rst:29
 msgid "`RTCBuilder` 1.1 (bundled in Eclipse [5_])"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:33
+#: ../../2.1_samplewordlogger.rst:33
 msgid "RTC の仕様 (I/O, Configuration)"
 msgstr "RTC spec (I/O, Configuration)"
 
-#: ..\..\2.1_samplewordlogger.rst:35
+#: ../../2.1_samplewordlogger.rst:35
 msgid "これから作成するコンポーネントを SampleWordLogger RTC と呼ぶことにします．"
 msgstr ""
 "Let's call the RT component we're about to create \"SampleWordLogger RTC\"."
 
-#: ..\..\2.1_samplewordlogger.rst:37
+#: ../../2.1_samplewordlogger.rst:37
 msgid ""
 "このコンポーネントは `TimedString` 型の入力ポート (`InPort`) を持ちます．今回はログをファイルへ出力するのみとし，`RTC` "
 "として出力ポート (`OutPort`) は持たないｋとにします．`InPort` 名を `result` とします．"
@@ -88,72 +88,72 @@ msgstr ""
 "want to save the log into a file and thus the RTC does not have output port "
 "(`OutPort`), and name `InPort` as `result`."
 
-#: ..\..\2.1_samplewordlogger.rst:39
+#: ../../2.1_samplewordlogger.rst:39
 msgid "ログファイルの場所は今回はハードコードします (お好みに変えて下さい)．"
 msgstr ""
 "This time we embed the log file path in the source (you can modify it if you"
 " want)."
 
-#: ..\..\2.1_samplewordlogger.rst:41
+#: ../../2.1_samplewordlogger.rst:41
 msgid "上から RTC の仕様を次のようにまとめます．"
 msgstr "Summarizing the RTC spec into the table:"
 
-#: ..\..\2.1_samplewordlogger.rst:44
+#: ../../2.1_samplewordlogger.rst:44
 msgid "Component Name"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:44
+#: ../../2.1_samplewordlogger.rst:44
 msgid "SampleWordLogger"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:46
+#: ../../2.1_samplewordlogger.rst:46
 msgid "InPort"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:48 ..\..\2.1_samplewordlogger.rst:54
+#: ../../2.1_samplewordlogger.rst:48 ../../2.1_samplewordlogger.rst:54
 msgid "Port Name"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:48
+#: ../../2.1_samplewordlogger.rst:48
 msgid "result"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:50 ..\..\2.1_samplewordlogger.rst:56
-#: ..\..\2.1_samplewordlogger.rst:62
+#: ../../2.1_samplewordlogger.rst:50 ../../2.1_samplewordlogger.rst:56
+#: ../../2.1_samplewordlogger.rst:62
 msgid "Data Type"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:50
+#: ../../2.1_samplewordlogger.rst:50
 msgid "TimedString"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:52
+#: ../../2.1_samplewordlogger.rst:52
 msgid "OutPort"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:54 ..\..\2.1_samplewordlogger.rst:56
-#: ..\..\2.1_samplewordlogger.rst:60 ..\..\2.1_samplewordlogger.rst:62
-#: ..\..\2.1_samplewordlogger.rst:64
+#: ../../2.1_samplewordlogger.rst:54 ../../2.1_samplewordlogger.rst:56
+#: ../../2.1_samplewordlogger.rst:60 ../../2.1_samplewordlogger.rst:62
+#: ../../2.1_samplewordlogger.rst:64
 msgid "(None)"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:58
+#: ../../2.1_samplewordlogger.rst:58
 msgid "Configuration"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:60
+#: ../../2.1_samplewordlogger.rst:60
 msgid "Parameter Name"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:64
+#: ../../2.1_samplewordlogger.rst:64
 msgid "Values"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:69
+#: ../../2.1_samplewordlogger.rst:69
 msgid "RTCBuilder のインストール，起動"
 msgstr "Install RTCBuilder"
 
-#: ..\..\2.1_samplewordlogger.rst:70
+#: ../../2.1_samplewordlogger.rst:70
 msgid ""
 "本章では `Eclipse` ベースのツール `OpenRTP (Open RT Platform)` に同梱される `RTBuilder` "
 "を利用するので，[2_]からダウンロード・インストールして下さい．"
@@ -162,7 +162,7 @@ msgstr ""
 "bundled in `OpenRTP (Open RT Platform)`. So download and install it from "
 "here[2_]."
 
-#: ..\..\2.1_samplewordlogger.rst:72
+#: ../../2.1_samplewordlogger.rst:72
 msgid ""
 "新規ワークスペースを指定して Eclipse を起動すると，以下のような Welcome ページが表示されます (`画像引用元 "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/fig1-1EclipseInit.png>`__)．"
@@ -171,7 +171,7 @@ msgstr ""
 "(`image source "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/fig1-1EclipseInit.png>`__)．"
 
-#: ..\..\2.1_samplewordlogger.rst:76
+#: ../../2.1_samplewordlogger.rst:76
 msgid ""
 "Welcome ページはいまは必要ないので左上の「×」ボタンを押して閉じてください (`画像引用元 "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/fig2-2PerspectiveSwitch.png>`__)．"
@@ -180,7 +180,7 @@ msgstr ""
 "close (`image source "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/fig2-2PerspectiveSwitch.png>`__)．"
 
-#: ..\..\2.1_samplewordlogger.rst:80
+#: ../../2.1_samplewordlogger.rst:80
 msgid ""
 "右上の「Open Perspective」ボタンを押下し，プルダウンの「Other…」 ボタンを押下します(`画像引用元 "
 "<http://www.openrtm.org/openrtm/sites/default/files/208/fig2-3PerspectiveSelection.png>`__)．"
@@ -189,19 +189,19 @@ msgstr ""
 "in the pulldown(`image source "
 "<http://www.openrtm.org/openrtm/sites/default/files/208/fig2-3PerspectiveSelection.png>`__)．"
 
-#: ..\..\2.1_samplewordlogger.rst:84
+#: ../../2.1_samplewordlogger.rst:84
 msgid "`RTC Builder` を選択することで，RTCBuilder が起動します．"
 msgstr "Choose `RTC Builder`."
 
-#: ..\..\2.1_samplewordlogger.rst:88
+#: ../../2.1_samplewordlogger.rst:88
 msgid "How to make RTC"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:91
+#: ../../2.1_samplewordlogger.rst:91
 msgid "新規プロジェクトの作成"
 msgstr "Create New Project"
 
-#: ..\..\2.1_samplewordlogger.rst:92
+#: ../../2.1_samplewordlogger.rst:92
 msgid ""
 "SampleWordLogger コンポーネントを作成するために，`RTCBuilder` で新規プロジェクトを "
 "作成する必要が有ります．画面上部のメニューから[ファイル]－[新規]－ [プロジェクト]を選択します．"
@@ -209,7 +209,7 @@ msgstr ""
 "We need to create a new `Eclipse` project on `RTCBuilder` in order to make "
 "`SampleWordLogger` RTC. Choose from menu at the top [File]-[New]-[Project]."
 
-#: ..\..\2.1_samplewordlogger.rst:96
+#: ../../2.1_samplewordlogger.rst:96
 msgid ""
 "表示された ｢新規プロジェクト｣ 画面において，｢その他｣－｢RTCビルダ｣ を選択し，｢次へ｣ "
 "をクリックします．｢プロジェクト名｣欄に作成するプロジェクト名 (ここでは SampleWordLogger) を入力して｢終了｣をクリックします．"
@@ -217,7 +217,7 @@ msgstr ""
 "In \"New Project\" window, ｢New｣-｢RTC Builder｣ then ｢Next｣. In ｢Project "
 "Name｣ field, type in `SampleWordLogger` then ｢Finish｣."
 
-#: ..\..\2.1_samplewordlogger.rst:100
+#: ../../2.1_samplewordlogger.rst:100
 msgid ""
 "指定した名称のプロジェクトが生成され，パッケージエクスプローラ内に追加されます． 生成したプロジェクト内には，デフォルト値が設定された RTC プロファ"
 " イル XML(RTC.xml) が自動的に生成されるのがわかると思います．"
@@ -226,7 +226,7 @@ msgstr ""
 "You'll see in the new project that RTC.xml, an `RTC profile` that contains "
 "default values, is automatically generated."
 
-#: ..\..\2.1_samplewordlogger.rst:104
+#: ../../2.1_samplewordlogger.rst:104
 msgid ""
 "`RTC.xml` が生成された時点で，このプロジェクトに関連付けられているワークスペースとして `RTCBuilder` "
 "のエディタが開くはずです．もし開かない場合は，ツールバーの｢Open New RtcBuilder Editor｣ボタンを押下するか，メニューバーの "
@@ -237,7 +237,7 @@ msgstr ""
 " ｢Open New RtcBuilder Editor｣, or on menu bar [file]-[Open New Builder "
 "Editor]."
 
-#: ..\..\2.1_samplewordlogger.rst:108
+#: ../../2.1_samplewordlogger.rst:108
 msgid ""
 "(`画像引用元 "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/fig2-10FileMenuOpenNewBuilder.png>`__)．"
@@ -245,19 +245,19 @@ msgstr ""
 "(`image source "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/fig2-10FileMenuOpenNewBuilder.png>`__)．"
 
-#: ..\..\2.1_samplewordlogger.rst:113
+#: ../../2.1_samplewordlogger.rst:113
 msgid "SampleWordLogger コンポーネントの雛型の生成"
 msgstr "Generate SampleWordLogger RTC template"
 
-#: ..\..\2.1_samplewordlogger.rst:115
+#: ../../2.1_samplewordlogger.rst:115
 msgid "SampleWordLogger RTC の雛型の生成は，`OpenRTP` に同梱の `RTCBuilder` を用いて行います．"
 msgstr "To generate the template of `SampleWordLogger RTC`, use `RTCBuilder`."
 
-#: ..\..\2.1_samplewordlogger.rst:118
+#: ../../2.1_samplewordlogger.rst:118
 msgid "プロファイル情報入力とコードの生成"
 msgstr "Input profile info and generate code"
 
-#: ..\..\2.1_samplewordlogger.rst:119
+#: ../../2.1_samplewordlogger.rst:119
 msgid ""
 "まず，いちばん左の「基本」タブを選択し，基本情報を入力します．先ほ ど決めた SampleWordLogger "
 "コンポーネントの仕様(名前)の他に，概要やバージョン等を入力してください．ラベルが赤字の項目は必須項目です．その他はデフォルトで構いません．"
@@ -266,7 +266,7 @@ msgstr ""
 " number in addition to RTC name. Labels in red are required (others can be "
 "default values)."
 
-#: ..\..\2.1_samplewordlogger.rst:123
+#: ../../2.1_samplewordlogger.rst:123
 msgid ""
 "次に，「アクティビティ」タブを選択し，使用するアクションコールバッ クを指定します． `SampleWordLogger RTC` "
 "では，onActivated(), onDeactivated(), onExecute() コールバックを使用します．下図のように (1) の "
@@ -280,7 +280,7 @@ msgstr ""
 " the radio button (2). Do so too for onDeactivated, onExecute (`image source"
 " <http://www.openrtm.org/openrtm/sites/default/files/1431/Activity.png>`__)."
 
-#: ..\..\2.1_samplewordlogger.rst:128
+#: ../../2.1_samplewordlogger.rst:128
 msgid ""
 "さらに，\"Data Ports\" タブを選択し，データポートの情報を入力します． "
 "先ほど決めた仕様を元に以下のように入力します．なお，変数名や表示位置はオプションで，そのままで結構です．"
@@ -288,7 +288,7 @@ msgstr ""
 "Select \"Data Ports\" tab and input data port info as we defined earlier. "
 "You can leave variable name, location."
 
-#: ..\..\2.1_samplewordlogger.rst:132
+#: ../../2.1_samplewordlogger.rst:132
 msgid ""
 "次に，「言語・環境」タブを選択し，プログラミング言語を選択します． ここでは，`C++` を選択します．なお，言語・環境はデフォルト等が "
 "設定されておらず，指定し忘れるとコード生成時にエラーになりますので， 必ず言語の指定を行うようにしてください．"
@@ -297,7 +297,7 @@ msgstr ""
 "Here choose `C++`. Note that in this tab no default values are set, and "
 "errors occur if you don't set anything. So be sure to work on."
 
-#: ..\..\2.1_samplewordlogger.rst:134
+#: ../../2.1_samplewordlogger.rst:134
 msgid ""
 "また，`C++` の場合デフォルトでは `CMake` を利用してビルドすることになって いますが，旧式の `VC` "
 "のプロジェクトやソリューションを直接 `RTCBuilder` が 生成する方法を利用したい場合は `Use old build "
@@ -307,13 +307,13 @@ msgstr ""
 " to using an older `VC` `project`, or to generating a `solution` directly by"
 " `RTCBuilder`, check `Use old build environment`."
 
-#: ..\..\2.1_samplewordlogger.rst:136
+#: ../../2.1_samplewordlogger.rst:136
 msgid "最後に，「基本」タブにある\"コード生成\"ボタンをクリックし，コンポー ネントの雛型を生成します．"
 msgstr ""
 "At last, in the tab 「Basic」 click \"Code Generatioin\" to generate the "
 "template of your RTC."
 
-#: ..\..\2.1_samplewordlogger.rst:138
+#: ../../2.1_samplewordlogger.rst:138
 msgid ""
 "※ 生成されるコード群は，eclipse 起動時に指定したワークスペースフォルダの中に生成されます．現在のワークスペースは，「ファイル(F)」 > "
 "「ワークスペースの切り替え(W)...」で確認することができます．"
@@ -321,11 +321,11 @@ msgstr ""
 "NOTE; codes are generated into the folder in the workspace you specified "
 "when `Eclipse` launched. You can check it by 「File(F)」 > 「Workspace(W)...」."
 
-#: ..\..\2.1_samplewordlogger.rst:141
+#: ../../2.1_samplewordlogger.rst:141
 msgid "仮ビルド"
 msgstr "Build tentatively"
 
-#: ..\..\2.1_samplewordlogger.rst:143
+#: ../../2.1_samplewordlogger.rst:143
 msgid ""
 "さて，ここまでで SampleWordLogger コンポーネントのソースコードが生成されました． 処理の中身は実装されていないので，`InPort` "
 "に他の `RTC` を接続しても何も出力されませんが，生成直後のソースコードだけでもコンパイルおよび実行はできます．"
@@ -334,13 +334,13 @@ msgstr ""
 "RTC` so far. Nothing will be output even when you connect anything to the "
 "`InPort` of your `RTC`, but you can build it."
 
-#: ..\..\2.1_samplewordlogger.rst:145
+#: ../../2.1_samplewordlogger.rst:145
 msgid "※サービスポートとプロバイダを持つコンポーネントの場合，実装を行わないとビルドが通らないものもあります．"
 msgstr ""
 "NOTE; With an RTC that has `service port` and `provider`, build might not "
 "pass without concrete code."
 
-#: ..\..\2.1_samplewordlogger.rst:147
+#: ../../2.1_samplewordlogger.rst:147
 msgid ""
 "では，まず `CMake` を利用してビルド環境の `Configure` を行います．Linuxで あれば，SampleWordLogger "
 "コンポーネントのソースが生成されたディレクトリで::"
@@ -348,7 +348,7 @@ msgstr ""
 "Ok, then do `Configure` the build environment by using `CMake`. Suppose on "
 "Linux, in the directory where the source of SampleWordLogger was generated::"
 
-#: ..\..\2.1_samplewordlogger.rst:152
+#: ../../2.1_samplewordlogger.rst:152
 msgid ""
 "とすれば，Configureおよびビルドが完了するはずです．`Windows` の場合は GUI を利用して `Configure` してみます． "
 "スタートメニューなどから `CMake (cmake-gui)` を起動します(`画像引用元 "
@@ -359,7 +359,7 @@ msgstr ""
 "`CMake (cmake-gui)`(`image source "
 "<http://www.openrtm.org/openrtm/sites/default/files/4625/CMakeGUI0.png>`__)．"
 
-#: ..\..\2.1_samplewordlogger.rst:156
+#: ../../2.1_samplewordlogger.rst:156
 msgid ""
 "画面上部に以下のようなテキストボックスがありますので，それぞれソースコードの場所(`CMakeList.txt` が有る場所) "
 "と，ビルドディレクトリを指定します．"
@@ -367,11 +367,11 @@ msgstr ""
 "On upper side you'll find a text box like below. Specify each location "
 "(where `CMakeList.txt` is located at, build directory)."
 
-#: ..\..\2.1_samplewordlogger.rst:158
+#: ../../2.1_samplewordlogger.rst:158
 msgid "Where is the soruce code ^ Where to build the binaries"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:160
+#: ../../2.1_samplewordlogger.rst:160
 msgid ""
 "ソースコードの場所は SampleWordLogger コンポーネントのソースが生成された場所で `CMakeList.txt` "
 "が存在するディレクトリです．デフォルトでは <ワークス ペースディレクトリ>/SampleWordLogger になります．"
@@ -380,7 +380,7 @@ msgstr ""
 "generated into and where `CMakeList.txt` resides. It's "
 "`<%WORKSPACE%>/SampleWordLogger` by default."
 
-#: ..\..\2.1_samplewordlogger.rst:162
+#: ../../2.1_samplewordlogger.rst:162
 msgid ""
 "また，ビルドディレクトリとは，ビルドするためのプロジェクトファイルやオブジェクトファイル，バイナリを格納する場所のことです．場所は任意ですが，この場合 "
 "<ワークスペースディレクトリ>/SampleWordLogger/build のように分かりやすい名前をつけた SampleWordLogger "
@@ -390,7 +390,7 @@ msgstr ""
 "building the project are kept. While it's arbitrary, we recommend "
 "understandable name e.g. <%WORKSPACE%>/SampleWordLogger/build."
 
-#: ..\..\2.1_samplewordlogger.rst:166
+#: ../../2.1_samplewordlogger.rst:166
 msgid ""
 "指定したら，下の `Configure` "
 "ボタンを押します．すると下図のようなダイアログが表示されますので，生成したいプロジェクトの種類を指定します．今回は `Visual Studio 10`"
@@ -401,7 +401,7 @@ msgstr ""
 " to make. Let's go for `Visual Studio 10` this time(`image source "
 "<http://www.openrtm.org/openrtm/sites/default/files/4625/CMakeGUI1.png>`__)．"
 
-#: ..\..\2.1_samplewordlogger.rst:170
+#: ../../2.1_samplewordlogger.rst:170
 msgid ""
 "ダイアログで Finish を押すと Configure が始まります．問題がなければ下部のログウインドウに Configuring done "
 "と出力されますので，続けて Generate ボタンを押します．Generating done "
@@ -412,7 +412,7 @@ msgstr ""
 "`Generate` button. When you see \"Generating done\", project/solution file "
 "is now ready."
 
-#: ..\..\2.1_samplewordlogger.rst:172
+#: ../../2.1_samplewordlogger.rst:172
 msgid ""
 "なお，`CMake` は Configure の段階でキャッシュファイルを生成しますので，トラブルなどで設定を変更したり環境を変更した場合は "
 "[File]-[Delete Cache] でキャッシュを削除して `Configure` からやり直してください．"
@@ -421,7 +421,7 @@ msgstr ""
 " re-run `Configure` after making change or stuck at issues, by "
 "[File]-[Delete Cache]."
 
-#: ..\..\2.1_samplewordlogger.rst:174
+#: ../../2.1_samplewordlogger.rst:174
 msgid ""
 "次に先ほど指定した `build` ディレクトリの中の SampleWordLogger.sln をダブルクリックして `Visual Studio "
 "2010` を起動します．"
@@ -429,31 +429,31 @@ msgstr ""
 "In the `build` directory you just specified, open `SampleWordLogger.sln` by "
 "double-clicking it, to start `Visual Studio 2010`."
 
-#: ..\..\2.1_samplewordlogger.rst:176
+#: ../../2.1_samplewordlogger.rst:176
 msgid ""
 "起動後，ソリューションエクスプローラーの `ALL_BUILD` "
 "を右クリックしビルドを選択してビルドします．特に問題がなければ正常にビルドが終了します．"
 msgstr "On `Solution Explorer`, right-click `ALL_BUILD` and choose `Build`."
 
-#: ..\..\2.1_samplewordlogger.rst:180
+#: ../../2.1_samplewordlogger.rst:180
 msgid "ここで `VC++ 2010` は閉じても構いません．"
 msgstr "Here you can close `VC++ 2010`."
 
-#: ..\..\2.1_samplewordlogger.rst:183
+#: ../../2.1_samplewordlogger.rst:183
 msgid "ヘッダ，ソースの編集"
 msgstr "Edit header, source files"
 
-#: ..\..\2.1_samplewordlogger.rst:186
+#: ../../2.1_samplewordlogger.rst:186
 msgid "アクティビティ処理の実装"
 msgstr "Implement Activity"
 
-#: ..\..\2.1_samplewordlogger.rst:187
+#: ../../2.1_samplewordlogger.rst:187
 msgid "SampleWordLogger RTC では，InPort から語を受け取った時刻とその語をファイルストリームに流します．"
 msgstr ""
 "SampleWordLogger RTC passes words received via `InPort` and the timestamp "
 "recorded at the reception event to file stream."
 
-#: ..\..\2.1_samplewordlogger.rst:189
+#: ../../2.1_samplewordlogger.rst:189
 msgid ""
 "`onActivated()`, `onExecute()`, `onDeactivated()` での処理内容を下図に示します (`編集用の図ファイル"
 " "
@@ -465,21 +465,21 @@ msgstr ""
 "<https://docs.google.com/drawings/d/19KHmLRoOhHJVumNMwcO7CrPV7lWUwmFB3CD5OfT6mIo/edit>`__"
 " if you with. Ask the edit privilege)．"
 
-#: ..\..\2.1_samplewordlogger.rst:194
+#: ../../2.1_samplewordlogger.rst:194
 msgid ".cpp ファイル編集"
 msgstr "Edit .cpp file"
 
-#: ..\..\2.1_samplewordlogger.rst:196
+#: ../../2.1_samplewordlogger.rst:196
 msgid "下記のように，`onActivated()`, `onDeactivated()`, `onExecute()` を実装します．::"
 msgstr ""
 "Write code for `onActivated()`, `onDeactivated()`, `onExecute()` as "
 "follows::"
 
-#: ..\..\2.1_samplewordlogger.rst:366
+#: ../../2.1_samplewordlogger.rst:366
 msgid "CMakeList.txt の編集"
 msgstr "Edit CMakeLists.txt"
 
-#: ..\..\2.1_samplewordlogger.rst:368
+#: ../../2.1_samplewordlogger.rst:368
 msgid ""
 "この RTC ではログファイル生成のために `xmllib` を使用しています (実際のログのフォーマットは xml ではありませんが) "
 "ので，`RTCBuilder` が生成した `CMakeLists.txt` にその旨を追記します．"
@@ -488,7 +488,7 @@ msgstr ""
 "(although we're not putting the content into `xml` in this sample).Therefore"
 " we add it to `CMakeLists.txt`."
 
-#: ..\..\2.1_samplewordlogger.rst:370
+#: ../../2.1_samplewordlogger.rst:370
 msgid ""
 "適当なエディタ (`VC++ 2010, Emacs` 等) 上で，`SampleWordLogger/CMakeLists.txt` "
 "を開いて下さい．::"
@@ -496,7 +496,7 @@ msgstr ""
 "Open `SampleWordLogger/CMakeLists.txt` in a text editor (`VC++ 2010, Emacs` "
 "etc)::"
 
-#: ..\..\2.1_samplewordlogger.rst:374
+#: ../../2.1_samplewordlogger.rst:374
 msgid ""
 "とあり，`src` フォルダの情報は移譲されていることが分かるので，`SampleWordLogger/src/CMakeLists.txt` "
 "を開きます．このファイル中を例えば以下の様に変更します::"
@@ -505,11 +505,11 @@ msgstr ""
 "`CMakeLists.txt` in that directory. So open "
 "`SampleWordLogger/src/CMakeLists.txt` and change like::"
 
-#: ..\..\2.1_samplewordlogger.rst:393
+#: ../../2.1_samplewordlogger.rst:393
 msgid "VC++ によるビルド"
 msgstr "Build by VC++"
 
-#: ..\..\2.1_samplewordlogger.rst:394
+#: ../../2.1_samplewordlogger.rst:394
 msgid ""
 "Visual C++ 2010 に戻ります．もし既に閉じていれば，再度 `SampleWordLogger.sln` "
 "ファイルをダブルクリックし，Visual C++ 2010 を起動します．Visual C++ 2010 "
@@ -520,23 +520,23 @@ msgstr ""
 "`SampleWordLogger.sln`). Then build RTC by doing as follows (`image source "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/VC++_build.png>`__)．"
 
-#: ..\..\2.1_samplewordlogger.rst:398
+#: ../../2.1_samplewordlogger.rst:398
 msgid "Visual C++ 2010 のコンソールにエラーが起きたと表示されなければ，以上で RTC 作成が終了です．"
 msgstr ""
 "If you don't see any error on `Visual C++ 2010` console, you're done "
 "finally!"
 
-#: ..\..\2.1_samplewordlogger.rst:402
+#: ../../2.1_samplewordlogger.rst:402
 msgid "実行方法"
 msgstr "HowToRun"
 
-#: ..\..\2.1_samplewordlogger.rst:403
+#: ../../2.1_samplewordlogger.rst:403
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 "Your current directory is assumed to be the home of the USB unless "
 "specified."
 
-#: ..\..\2.1_samplewordlogger.rst:409
+#: ../../2.1_samplewordlogger.rst:409
 msgid ""
 "では実行してみましょう． `SampleWordLogger` は単体だと何も行わないので，先に紹介された `MotionByVoiceDemo` "
 "と組合せて発話を記録してみましょう．"
@@ -544,7 +544,7 @@ msgstr ""
 "Let's run/play the game! `SampleWordLogger` by itself doesn't do anything. "
 "Run together `MotionByVoiceDemo` that we saw earlier to record what you say."
 
-#: ..\..\2.1_samplewordlogger.rst:412
+#: ../../2.1_samplewordlogger.rst:412
 msgid ""
 "上記二つのフォルダからそれぞれに格納される RTC を呼ぶための .bat ファイルを既に "
 "`./demo/MotionByVoiceLoggerDemo` として用意してあります．"
@@ -552,11 +552,11 @@ msgstr ""
 "`.bat` files to call involved RTCs are already made for you in "
 "`./demo/MotionByVoiceLoggerDemo`."
 
-#: ..\..\2.1_samplewordlogger.rst:414
+#: ../../2.1_samplewordlogger.rst:414
 msgid "MotionByVoiceLoggerDemo"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:416
+#: ../../2.1_samplewordlogger.rst:416
 msgid ""
 "`./demo/MotionByVoiceLoggerDemo` から "
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\" "
@@ -566,7 +566,7 @@ msgstr ""
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\", respectively"
 " by clicking the link below. If it doesn't work then do so from  `Explorer`."
 
-#: ..\..\2.1_samplewordlogger.rst:432
+#: ../../2.1_samplewordlogger.rst:432
 msgid ""
 "`MotionByVoiceDemo のチュートリアル <1.4_callmotion_byvoice.html#HowToRun>`__ "
 "に従い，発話デモを実行．"
@@ -574,7 +574,7 @@ msgstr ""
 "Run demo as the same you did in `MotionByVoiceDemo tutorial "
 "<1.4_callmotion_byvoice.html#HowToRun>`__ "
 
-#: ..\..\2.1_samplewordlogger.rst:434
+#: ../../2.1_samplewordlogger.rst:434
 msgid ""
 "\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" "
 "の順に実行し，RT システムを停止．"
@@ -582,7 +582,7 @@ msgstr ""
 "Click \"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\", "
 "respectively."
 
-#: ..\..\2.1_samplewordlogger.rst:444
+#: ../../2.1_samplewordlogger.rst:444
 msgid ""
 "`./demo/SampleWordLogger/build/Debug/SampleWord.log` "
 "をテキストエディタで開くと，下の例のように，時刻と発話内容が記録されている．"
@@ -590,23 +590,23 @@ msgstr ""
 "You'll see the timestamp and the word spoken in "
 "`./demo/SampleWordLogger/build/Debug/SampleWord.log`."
 
-#: ..\..\2.1_samplewordlogger.rst:446
+#: ../../2.1_samplewordlogger.rst:446
 msgid ""
 "2014/03/13 08:56:31 左 さげて 2014/03/13 08:56:44 右 あげて 2014/03/13 08:57:08 左 "
 "よろしく 2014/03/13 08:58:23 左 あげて 2014/03/13 08:58:39 左 あげない"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:467
+#: ../../2.1_samplewordlogger.rst:467
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<2.2_samplemotionselector.html>`__ |"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:469
+#: ../../2.1_samplewordlogger.rst:469
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:407
+#: ../../2.1_samplewordlogger.rst:407
 msgid ""
 "For starting necessary services, quickly go [run-common-tools_] and come "
 "back."

--- a/doc/locale/en/LC_MESSAGES/2.2_samplemotionselector.po
+++ b/doc/locale/en/LC_MESSAGES/2.2_samplemotionselector.po
@@ -11,53 +11,53 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\2.2_samplemotionselector.rst:1
+#: ../../2.2_samplemotionselector.rst:1
 msgid "**(RTC 作成 2) Choreonoid のモーションを選択する RTC の開発**"
 msgstr ""
 "`(Dev 2) Motion RTC that Calls Motions on Choreonoid from Keyboard Input "
 "<2.2_samplemotionselector.html>`_"
 
-#: ..\..\2.2_samplemotionselector.rst:12
+#: ../../2.2_samplemotionselector.rst:12
 msgid "Introduction"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:15
+#: ../../2.2_samplemotionselector.rst:15
 msgid "このページで体験すること"
 msgstr "What you'll experience"
 
-#: ..\..\2.2_samplemotionselector.rst:17
+#: ../../2.2_samplemotionselector.rst:17
 msgid ""
 "キーボードからの入力によって， Choreonoidのモーションを呼び出すことが出来る `SampleMotionCaller RTC` の開発"
 msgstr ""
 "Making Motion RTC that Calls Motions on Choreonoid from Keyboard Input"
 
-#: ..\..\2.2_samplemotionselector.rst:20
+#: ../../2.2_samplemotionselector.rst:20
 msgid "関連するチュートリアル"
 msgstr "Related Tutorials"
 
-#: ..\..\2.2_samplemotionselector.rst:21
+#: ../../2.2_samplemotionselector.rst:21
 msgid "前章 (Logger RTC 開発)[1_]を終了し，`RTC` のスクラッチからの作成方法を習得していることを前提としています．"
 msgstr ""
 "Assumed that you finished previous tutorial (Logger RTC development)[1_]  "
 "and understand how to create `RTC` from scratch."
 
-#: ..\..\2.2_samplemotionselector.rst:24
+#: ../../2.2_samplemotionselector.rst:24
 msgid "SystemEnvironment"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:25
+#: ../../2.2_samplemotionselector.rst:25
 msgid "前章 (Logger RTC 開発)[1_]に同じ．"
 msgstr "same as previous tutorial (Logger RTC development)[1_]."
 
-#: ..\..\2.2_samplemotionselector.rst:29
+#: ../../2.2_samplemotionselector.rst:29
 msgid "RTC の仕様 (I/O, Configuration)"
 msgstr "RTC spec (I/O, Configuration)"
 
-#: ..\..\2.2_samplemotionselector.rst:31
+#: ../../2.2_samplemotionselector.rst:31
 msgid "これから作成するコンポーネントを `SampleMotionCaller` RTC と呼ぶことにします．"
 msgstr "We'll call the RTC we're making as `SampleMotionCaller`."
 
-#: ..\..\2.2_samplemotionselector.rst:33
+#: ../../2.2_samplemotionselector.rst:33
 msgid ""
 "このコンポーネントは，キーボードからの入力を受け付けるので `InPort` は未指定です．入力を解釈した結果を `TimedString` で "
 "`OutPort` へ出力します．"
@@ -66,84 +66,84 @@ msgstr ""
 "that's it. Output the result of the input into `OutPort` as `TimedString` "
 "type."
 
-#: ..\..\2.2_samplemotionselector.rst:36
+#: ../../2.2_samplemotionselector.rst:36
 msgid "RTC I/O Spec"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:39
+#: ../../2.2_samplemotionselector.rst:39
 msgid "Component Name"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:39
+#: ../../2.2_samplemotionselector.rst:39
 msgid "SampleMotionCaller"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:41
+#: ../../2.2_samplemotionselector.rst:41
 msgid "InPort"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:43 ..\..\2.2_samplemotionselector.rst:49
+#: ../../2.2_samplemotionselector.rst:43 ../../2.2_samplemotionselector.rst:49
 msgid "Port Name"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:43 ..\..\2.2_samplemotionselector.rst:45
-#: ..\..\2.2_samplemotionselector.rst:49 ..\..\2.2_samplemotionselector.rst:55
-#: ..\..\2.2_samplemotionselector.rst:57 ..\..\2.2_samplemotionselector.rst:59
+#: ../../2.2_samplemotionselector.rst:43 ../../2.2_samplemotionselector.rst:45
+#: ../../2.2_samplemotionselector.rst:49 ../../2.2_samplemotionselector.rst:55
+#: ../../2.2_samplemotionselector.rst:57 ../../2.2_samplemotionselector.rst:59
 msgid "(None)"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:45 ..\..\2.2_samplemotionselector.rst:51
-#: ..\..\2.2_samplemotionselector.rst:57
+#: ../../2.2_samplemotionselector.rst:45 ../../2.2_samplemotionselector.rst:51
+#: ../../2.2_samplemotionselector.rst:57
 msgid "Data Type"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:47
+#: ../../2.2_samplemotionselector.rst:47
 msgid "OutPort"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:51
+#: ../../2.2_samplemotionselector.rst:51
 msgid "TimedString"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:53
+#: ../../2.2_samplemotionselector.rst:53
 msgid "Configuration"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:55
+#: ../../2.2_samplemotionselector.rst:55
 msgid "Parameter Name"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:59
+#: ../../2.2_samplemotionselector.rst:59
 msgid "Values"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:62
+#: ../../2.2_samplemotionselector.rst:62
 msgid "SampleMotionCaller RTC では、onExecute() コールバックのみ使用します。"
 msgstr "In `SampleMotionCaller RTC` only `onExecute()` is used."
 
-#: ..\..\2.2_samplemotionselector.rst:66
+#: ../../2.2_samplemotionselector.rst:66
 msgid "How to make RTC"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:67
+#: ../../2.2_samplemotionselector.rst:67
 msgid "`RTC Builder` を用いた初期設定は省略します．前章[1_]で習得したことを用い，上記設計を実装して下さい．"
 msgstr ""
 "We'll skip how to do intial setting on `RTC Builder`; Please refer to the "
 "previous tutorial[1_] and implement the design above."
 
-#: ..\..\2.2_samplemotionselector.rst:69
+#: ../../2.2_samplemotionselector.rst:69
 msgid "ここで `VC++ 2010` は閉じても構いません．"
 msgstr "You can close `VC++ 2010` at this moment."
 
-#: ..\..\2.2_samplemotionselector.rst:72
+#: ../../2.2_samplemotionselector.rst:72
 msgid "ヘッダ，ソースの編集"
 msgstr "Edit header, source files"
 
-#: ..\..\2.2_samplemotionselector.rst:75
+#: ../../2.2_samplemotionselector.rst:75
 msgid ".h, .cpp ファイル編集"
 msgstr "Edit .h, .cpp"
 
-#: ..\..\2.2_samplemotionselector.rst:77
+#: ../../2.2_samplemotionselector.rst:77
 msgid ""
 "`.demo/SampleMotionCaller/include/SampleMotionCaller/SampleMotionCaller.h` "
 "に次のように追加します::"
@@ -151,11 +151,11 @@ msgstr ""
 "Add to "
 "`.demo/SampleMotionCaller/include/SampleMotionCaller/SampleMotionCaller.h`::"
 
-#: ..\..\2.2_samplemotionselector.rst:84
+#: ../../2.2_samplemotionselector.rst:84
 msgid "下記のように `onExecute()` を実装します．::"
 msgstr "Write `onExecute()` as::"
 
-#: ..\..\2.2_samplemotionselector.rst:153
+#: ../../2.2_samplemotionselector.rst:153
 msgid ""
 "ファイル全体はこちらで閲覧可能: - `.demo/SampleMotionCaller/src/SampleMotionCaller.cpp` - "
 "`demo/SampleMotionCaller/include/SampleMotionCaller/SampleMotionCaller.h`"
@@ -164,21 +164,21 @@ msgstr ""
 "`.demo/SampleMotionCaller/src/SampleMotionCaller.cpp` - "
 "`demo/SampleMotionCaller/include/SampleMotionCaller/SampleMotionCaller.h`"
 
-#: ..\..\2.2_samplemotionselector.rst:158
+#: ../../2.2_samplemotionselector.rst:158
 msgid "CMakeList.txt の編集"
 msgstr "Edit CMakeLists.txt"
 
-#: ..\..\2.2_samplemotionselector.rst:160
+#: ../../2.2_samplemotionselector.rst:160
 msgid "この RTC では Windows 標準ライブラリのみ使用するので，`CMakeLists.txt` の編集は不要です．"
 msgstr ""
 "No need to edit `CMakeLists.txt` since this `RTC` only uses standard Windows"
 " library."
 
-#: ..\..\2.2_samplemotionselector.rst:163
+#: ../../2.2_samplemotionselector.rst:163
 msgid "VC++ によるビルド"
 msgstr "Build by VC++"
 
-#: ..\..\2.2_samplemotionselector.rst:164
+#: ../../2.2_samplemotionselector.rst:164
 msgid ""
 "Visual C++ 2010 に戻ります．もし既に閉じていれば，再度 `SampleMotionCaller.sln` "
 "ファイルをダブルクリックし，Visual C++ 2010 を起動します．Visual C++ "
@@ -190,23 +190,23 @@ msgstr ""
 " "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/VC++_build.png>`__)．"
 
-#: ..\..\2.2_samplemotionselector.rst:168
+#: ../../2.2_samplemotionselector.rst:168
 msgid "Visual C++ 2010 のコンソールにエラーが起きたと表示されなければ，以上で RTC 作成が終了です．"
 msgstr ""
 "If you don't see any error on `Visual C++ 2010` console, you're done "
 "finally!"
 
-#: ..\..\2.2_samplemotionselector.rst:172
+#: ../../2.2_samplemotionselector.rst:172
 msgid "実行方法"
 msgstr "HowToRun"
 
-#: ..\..\2.2_samplemotionselector.rst:173
+#: ../../2.2_samplemotionselector.rst:173
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 "Your current directory is assumed to be the home of the USB unless "
 "specified."
 
-#: ..\..\2.2_samplemotionselector.rst:179
+#: ../../2.2_samplemotionselector.rst:179
 msgid ""
 "では実行してみましょう． `Choreonoid` 上で `GRobot` を走らせ，`SampleMotionCaller` "
 "から指示を送ってみましょう．"
@@ -214,7 +214,7 @@ msgstr ""
 "Let's run/play the game! Run `GRobot` on `Choreonoid`, then send commands "
 "from `SampleMotionCaller`."
 
-#: ..\..\2.2_samplemotionselector.rst:184
+#: ../../2.2_samplemotionselector.rst:184
 msgid ""
 "`./demo/SampleMotionCaller` から "
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\" "
@@ -224,7 +224,7 @@ msgstr ""
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\", respectively"
 " by clicking the link below. If it doesn't work then do so from  `Explorer`."
 
-#: ..\..\2.2_samplemotionselector.rst:194
+#: ../../2.2_samplemotionselector.rst:194
 msgid ""
 "RT System Editor で見てみると，`SampleMotionCaller` の RTC "
 "も実行されているのが確認可能．立ち上がるプロンプト内にコマンド情報が表示される．"
@@ -232,11 +232,11 @@ msgstr ""
 "Open `RT System Editor` and you'll see `SampleMotionCaller RTC` is running. "
 "List of available commands are shown on the command prompt."
 
-#: ..\..\2.2_samplemotionselector.rst:196
+#: ../../2.2_samplemotionselector.rst:196
 msgid "のプロンプト上で表示されたコマンドをキーボードから入力．`Choreonoid` 上でロボットが指示に従い動作する"
 msgstr "type in a command, then robot moves on `Choreonoid` accordingly."
 
-#: ..\..\2.2_samplemotionselector.rst:198
+#: ../../2.2_samplemotionselector.rst:198
 msgid ""
 "\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" "
 "の順に実行し，RT システムを停止．"
@@ -244,18 +244,18 @@ msgstr ""
 "Click \"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\", "
 "respectively."
 
-#: ..\..\2.2_samplemotionselector.rst:182
+#: ../../2.2_samplemotionselector.rst:182
 msgid ""
 "`Choreonoid` と `SampleMotionCaller` を簡便に呼び出すための .bat ファイルを既に "
 "`./demo/`SampleMotionCaller` に用意してあります．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:219
+#: ../../2.2_samplemotionselector.rst:219
 msgid ""
 "Go back to `index <top.html>`__ | Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:177
+#: ../../2.2_samplemotionselector.rst:177
 msgid ""
 "For starting necessary services, quickly go [run-common-tools_] and come "
 "back."

--- a/doc/locale/en/LC_MESSAGES/index.po
+++ b/doc/locale/en/LC_MESSAGES/index.po
@@ -11,11 +11,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\index.rst:8
+#: ../../index.rst:8
 msgid "RT Middleware Tutorial USB"
 msgstr ""
 
-#: ..\..\index.rst:10
+#: ../../index.rst:10
 msgid ""
 "`日本語 <../../locale/ja/top.html>`_ | `English <../../locale/en/top.html>`_"
 msgstr ""

--- a/doc/locale/en/LC_MESSAGES/top.po
+++ b/doc/locale/en/LC_MESSAGES/top.po
@@ -11,52 +11,52 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\top.rst:3
+#: ../../top.rst:3
 msgid "RT Middleware 体験用チュートリアル用 USB"
 msgstr "RT Middleware tutorial USB"
 
-#: ..\..\top.rst:6
+#: ../../top.rst:6
 msgid "デモの体験"
 msgstr "Experience Demos"
 
-#: ..\..\top.rst:16
+#: ../../top.rst:16
 msgid "RTC 開発の体験"
 msgstr "Let's Make RTCs"
 
-#: ..\..\top.rst:8
+#: ../../top.rst:8
 msgid "`(デモ 1) 画像処理 (OpenRTM-aist，OpenCV) <1.1_demo_imageprocessing.html>`_"
 msgstr ""
 "`(Demo 1) Image Processing (OpenRTM-aist，OpenCV) "
 "<1.1_demo_imageprocessing.html>`_"
 
-#: ..\..\top.rst:9
+#: ../../top.rst:9
 msgid "`(デモ 2) 音声命令による動画再生 (OpenHRI) <1.2_demo_mediaplaybyvoice.html>`_"
 msgstr ""
 "`(Demo 2) Playing Movie via Voice (OpenHRI) "
 "<1.2_demo_mediaplaybyvoice.html>`_"
 
-#: ..\..\top.rst:10
+#: ../../top.rst:10
 msgid ""
 "`(デモ 3) ロボットモーションの新規作成 (Choreonoid) <1.3_choreonoid_createmotion.html>`_"
 msgstr ""
 "`(Demo 3) Create Robot Motions (Choreonoid) "
 "<1.3_choreonoid_createmotion.html>`_"
 
-#: ..\..\top.rst:11
+#: ../../top.rst:11
 msgid ""
 "`(デモ 4) 音声命令によるモーションの再生 (OpenHRI，Choreonoid) <1.4_callmotion_byvoice.html>`_"
 msgstr ""
 "`(Demo 4) Playing Motions via Voice (OpenHRI，Choreonoid) "
 "<1.4_callmotion_byvoice.html>`_"
 
-#: ..\..\top.rst:12
+#: ../../top.rst:12
 msgid ""
 "`(デモ 5) 状態遷移モデル変更による，新たなモーション実行 (SEATSAT) <1.5_modifystate_seatsat.html>`_"
 msgstr ""
 "`(Demo 5) Running New Motions Along with State Transion (SEATSAT) "
 "<1.5_modifystate_seatsat.html>`_"
 
-#: ..\..\top.rst:18
+#: ../../top.rst:18
 msgid ""
 "`(開発 1) 音声認識されたキーワードのログを取得し，時刻とともにファイルに保存する ロガー RTC の開発 "
 "<2.1_samplewordlogger.html>`_"
@@ -64,7 +64,7 @@ msgstr ""
 "`(Dev 1) Logger RTC that Saves the Voice-recognized Time-stamped Keywords "
 "<2.1_samplewordlogger.html>`_"
 
-#: ..\..\top.rst:19
+#: ../../top.rst:19
 msgid ""
 "`(開発 2) キーボードからの入力によって Choreonoid のモーションを呼び出すことが出来る RTC の開発 "
 "<2.2_samplemotionselector.html>`_"
@@ -72,7 +72,7 @@ msgstr ""
 "`(Dev 2) Motion RTC that Calls Motions on Choreonoid from Keyboard Input "
 "<2.2_samplemotionselector.html>`_"
 
-#: ..\..\top.rst:13
+#: ../../top.rst:13
 msgid "`(デモ 6) アカデミック スカラロボットの制御 <1.6_scararobot_control.html>`_"
 msgstr ""
 "`(Demo 6) Academic SCARA Robot Control <1.6_scararobot_control.html>`_"

--- a/doc/locale/ja/LC_MESSAGES/1.1_demo_imageprocessing.po
+++ b/doc/locale/ja/LC_MESSAGES/1.1_demo_imageprocessing.po
@@ -11,189 +11,189 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.1_demo_imageprocessing.rst:1
+#: ../../1.1_demo_imageprocessing.rst:1
 msgid "**(デモ 1) 画像処理 (OpenRTM-aist，OpenCV)**"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:11
+#: ../../1.1_demo_imageprocessing.rst:11
 msgid "Introduction"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:14
+#: ../../1.1_demo_imageprocessing.rst:14
 msgid "関連するチュートリアル"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:15
+#: ../../1.1_demo_imageprocessing.rst:15
 msgid ""
 "http://www.openrtm.org/openrtm/ja/node/4625 - ネット接続不可の場合は "
 "./doc/tutorial_openrtm_opencv_cmake_imgprocessing.pdf"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:19
+#: ../../1.1_demo_imageprocessing.rst:19
 msgid "このページで体験すること"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:20
+#: ../../1.1_demo_imageprocessing.rst:20
 msgid "カメラで認識する動画像を反転 (OpenRTM-aist，OpenCV による)"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:21
+#: ../../1.1_demo_imageprocessing.rst:21
 msgid "`RT System Editor` の初歩的な利用法"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:24
+#: ../../1.1_demo_imageprocessing.rst:24
 msgid "動作環境"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:25
+#: ../../1.1_demo_imageprocessing.rst:25
 msgid "Windows 7／ 8"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:26
+#: ../../1.1_demo_imageprocessing.rst:26
 msgid ""
 "Java Runtime Environment (JRE) 7 "
 "(`../misc/openjdk_1.7.0_u45_2.4.3_installed` として同梱，インストール不要)"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:30
+#: ../../1.1_demo_imageprocessing.rst:30
 msgid "実行方法"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:31
+#: ../../1.1_demo_imageprocessing.rst:31
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:34
+#: ../../1.1_demo_imageprocessing.rst:34
 msgid "nameserver 起動 (全チュートリアル共通)"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:35
+#: ../../1.1_demo_imageprocessing.rst:35
 msgid "基本的に `OpenRTM` の nameserver は一度起動すると，起動したままでもすべてのチュートリアルは動作すると思われます．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:37
+#: ../../1.1_demo_imageprocessing.rst:37
 msgid "次のリンクをクリックして nameserver を起動．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:48
+#: ../../1.1_demo_imageprocessing.rst:48
 msgid "Starting omniNames for the first time. : Checkpointing completed."
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:52
+#: ../../1.1_demo_imageprocessing.rst:52
 msgid "上記手順で `cmd.exe` が消えてしまう場合は，`nameserver` がうまく起動していないので次の手順で原因を発見："
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:54
+#: ../../1.1_demo_imageprocessing.rst:54
 msgid "2.1) `Explorer` 上で，USB のドライヴ名を確認 (D/E/F etc. ここでは `F` と仮定)"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:56
+#: ../../1.1_demo_imageprocessing.rst:56
 msgid "2.2) `cmd.exe` を手動起動 (Win 7: [4_], Win 8: [5_])"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:58
+#: ../../1.1_demo_imageprocessing.rst:58
 msgid "2.3) 以下コマンドでフォルダ移動・コマンド実行::"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:64
+#: ../../1.1_demo_imageprocessing.rst:64
 msgid ""
 "エラー等発生していればここで表示されるのでその内容を診断．`OpenRTM` の `nameserver` の問題は WEB "
 "で検索して対処してみてください．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:67
+#: ../../1.1_demo_imageprocessing.rst:67
 msgid "チュートリアルのプログラム実行"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:69
+#: ../../1.1_demo_imageprocessing.rst:69
 msgid ""
 "`./demo/OpencvRtmDemo/0_StartDemo.bat` を実行．次のリンクから起動できなければ，手動で `Explorer` "
 "から実行．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:75
+#: ../../1.1_demo_imageprocessing.rst:75
 msgid "./demo/RTSE.bat を実行．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:81
+#: ../../1.1_demo_imageprocessing.rst:81
 msgid "RT System Editor が下図のように起動する．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:85
+#: ../../1.1_demo_imageprocessing.rst:85
 msgid ""
 "左側のペインで 127.0.0.1 を選択し直上の右矢印をクリックすると，起動中の RT Component が同ペイン上に表示される．ここでは "
 "`DirectShowCamComp`，`FlipComp`，`CameraViewerComp` となるはず．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:87
+#: ../../1.1_demo_imageprocessing.rst:87
 msgid ""
 "File --> Open New System Editor を選ぶと，`System Diagram` "
 "が真ん中のペインに開かれる．左側のペインから各 RTC を System Diagram にドラッグすると下図のように表示される．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:91
+#: ../../1.1_demo_imageprocessing.rst:91
 msgid "同ペイン上で各 RTC を接続．上に挙げた三つの RTC を左から接続する．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:93
+#: ../../1.1_demo_imageprocessing.rst:93
 msgid "同ペイン上で直上左にある \"ALL\" というアイコンをクリック，すべての RTC を activate (参考リンク 1_)"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:97
+#: ../../1.1_demo_imageprocessing.rst:97
 msgid ""
 "`CaptureImage` というウィンドウにカメラ画像が表示されれば入出力・接続が成功．同時に `DirectShowCamComp` "
 "のコマンドプロンプトにも `frame rate` が定期的に追加表示される．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:101
+#: ../../1.1_demo_imageprocessing.rst:101
 msgid ""
 "`RTSystemEditor` 上で flip_mode の値を 1 --> 0 --> -1 と変える (Apply を忘れずに) "
 "とカメラ画像も変わることを確認できる．`flip_mode` の値と対応する挙動は次のようになる (画像引用元 2_)"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:105
+#: ../../1.1_demo_imageprocessing.rst:105
 msgid "終了するには，次の手順で \"RTC を inactivate\" --> \"RTC 間のリンクを切り離し\" --> \"各 RTC を停止\" を行う．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:107
+#: ../../1.1_demo_imageprocessing.rst:107
 msgid "同ペイン上で直上左にある \"All Deactivate\" というアイコンをクリック"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:108
+#: ../../1.1_demo_imageprocessing.rst:108
 msgid "で行ったのと逆を行う -- つまり，各接続線上で右クリックし\"切断\"を選択"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:109
+#: ../../1.1_demo_imageprocessing.rst:109
 msgid "で起動されたコマンドプロンプト群を手動で終了．ただし `rtm-naming.bat` のそれは停止せずとも良い．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:111
+#: ../../1.1_demo_imageprocessing.rst:111
 msgid ""
 "ここで挙げた終了手順はやや煩雑ですが，御心配なく．次のチュートリアルからはこれらを一括して行うスクリプトを用意してあります．今回は初回なのでほぼすべてを手動で行い，`OpenRTM`"
 " のプログラム実行に必要な手順を体験して頂きました．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:45
+#: ../../1.1_demo_imageprocessing.rst:45
 msgid ""
 "(上記方法でうまく行かなかった場合のみ以降実施) `Explorer` で `demo` フォルダを開き，`rtm-naming.bat` "
 "をダブルクリックして実行．"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:123
+#: ../../1.1_demo_imageprocessing.rst:123
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<1.2_demo_mediaplaybyvoice.html>`__ |"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:125
+#: ../../1.1_demo_imageprocessing.rst:125
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:50
+#: ../../1.1_demo_imageprocessing.rst:50
 msgid "`cmd.exe` (Command prompt) が開きっぱなしになり，次のような文言が表示されれば成功．::"
 msgstr ""
 
-#: ..\..\1.1_demo_imageprocessing.rst:27
+#: ../../1.1_demo_imageprocessing.rst:27
 msgid "Internet Explorer (IE 以外のブラウザでは正常に動作しません)"
 msgstr ""
 

--- a/doc/locale/ja/LC_MESSAGES/1.2_demo_mediaplaybyvoice.po
+++ b/doc/locale/ja/LC_MESSAGES/1.2_demo_mediaplaybyvoice.po
@@ -11,85 +11,85 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:1
+#: ../../1.2_demo_mediaplaybyvoice.rst:1
 msgid "**(デモ 2) 音声命令による動画再生 (OpenHRI)**"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:11
+#: ../../1.2_demo_mediaplaybyvoice.rst:11
 msgid "関連するチュートリアル"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:12
+#: ../../1.2_demo_mediaplaybyvoice.rst:12
 msgid "当ページでは最低限の操作方法のみ紹介します．`OpenHRI`, `SEATSAT` の詳細ては下記リンクを参照ください．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:14
+#: ../../1.2_demo_mediaplaybyvoice.rst:14
 msgid "当ページで紹介するデモの詳細．ページ内下方にある \"システムを起動する\"，\"動作例\" の章にしたがって作業を行ってください．[1_]"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:16
+#: ../../1.2_demo_mediaplaybyvoice.rst:16
 msgid "なおソフトウェアは `./demo/0_SpeechDemo` にも梱包してあります．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:17
+#: ../../1.2_demo_mediaplaybyvoice.rst:17
 msgid ""
 "ネット接続不可の場合のために同チュートリアル PDF を同梱しています ./doc/tutorial_openhri_mediaplay.pdf"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:20
+#: ../../1.2_demo_mediaplaybyvoice.rst:20
 msgid "HowToRun"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:21
+#: ../../1.2_demo_mediaplaybyvoice.rst:21
 msgid "他のウィンドウの陰に表示されることがあるのでその場合は探して前面に移動．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:23
+#: ../../1.2_demo_mediaplaybyvoice.rst:23
 msgid ""
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\" "
 "の順に，下記リンクをクリックして実行．クリックして動作していなそうな場合，Explorer で \"./demo/0 SpeechDemo\" "
 "を開いてそれぞれ実行．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:33
+#: ../../1.2_demo_mediaplaybyvoice.rst:33
 msgid "\"tk\" と表示されるウィンドウを前面に移動．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:35
+#: ../../1.2_demo_mediaplaybyvoice.rst:35
 msgid "\"ビデオ\" と発話．\"video_list_mode\" と左肩に書かれた tk ウィンドウが表示される．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:37
+#: ../../1.2_demo_mediaplaybyvoice.rst:37
 msgid "\"リスト\" と発話．\"PlayList\" ウィンドウが表示される．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:39
+#: ../../1.2_demo_mediaplaybyvoice.rst:39
 msgid "\"xばんめ\" (x = 1...5) と発話．\"PlayList\" ウィンドウ上でハイライト選択領域が変わる．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:41
+#: ../../1.2_demo_mediaplaybyvoice.rst:41
 msgid "\"再生\" と発話．\"Player\" ウィンドウで指定動画が再生される．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:43
+#: ../../1.2_demo_mediaplaybyvoice.rst:43
 msgid "\"停止\" など試す．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:45
+#: ../../1.2_demo_mediaplaybyvoice.rst:45
 msgid "終了時は，\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" の順に実行．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:55
+#: ../../1.2_demo_mediaplaybyvoice.rst:55
 msgid "RTC の deactivation は，コンポーネントがロードした実行時の必要リソースの量によって，時間がかかることがあります．"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:67
+#: ../../1.2_demo_mediaplaybyvoice.rst:67
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<1.3_choreonoid_createmotion.html>`__ |"
 msgstr ""
 
-#: ..\..\1.2_demo_mediaplaybyvoice.rst:69
+#: ../../1.2_demo_mediaplaybyvoice.rst:69
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 

--- a/doc/locale/ja/LC_MESSAGES/1.3_choreonoid_createmotion.po
+++ b/doc/locale/ja/LC_MESSAGES/1.3_choreonoid_createmotion.po
@@ -11,112 +11,112 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.3_choreonoid_createmotion.rst:1
+#: ../../1.3_choreonoid_createmotion.rst:1
 msgid "**(デモ 3) ロボットモーションの新規作成 (Choreonoid)**"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:11
+#: ../../1.3_choreonoid_createmotion.rst:11
 msgid "このページで体験すること"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:13
+#: ../../1.3_choreonoid_createmotion.rst:13
 msgid "`Choreonoid` 上で，既存のロボットモーションサンプルに自作のモーションを追加する．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:16
+#: ../../1.3_choreonoid_createmotion.rst:16
 msgid "関連するチュートリアル"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:17
+#: ../../1.3_choreonoid_createmotion.rst:17
 msgid "当ページでは最低限の操作方法のみ紹介します．`Choreonoid` に関する詳細は下記リンクを参照ください．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:19
+#: ../../1.3_choreonoid_createmotion.rst:19
 msgid "概要，詳細な使用法に関しては[1_]"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:20
+#: ../../1.3_choreonoid_createmotion.rst:20
 msgid "モーション変更に関する詳細は[2_]"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:23
+#: ../../1.3_choreonoid_createmotion.rst:23
 msgid "動作環境"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:24
+#: ../../1.3_choreonoid_createmotion.rst:24
 msgid "Windows 7／ 8"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:27
+#: ../../1.3_choreonoid_createmotion.rst:27
 msgid "実行方法"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:28
+#: ../../1.3_choreonoid_createmotion.rst:28
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:30
+#: ../../1.3_choreonoid_createmotion.rst:30
 msgid ".demo/BatchFiles/Choreonoid-GRobot.bat を実行．`Choreonoid` の GUI が起動する．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:36
+#: ../../1.3_choreonoid_createmotion.rst:36
 msgid "`Choreonoid` の GUI 上で，次の手順で既存モーションを読み込む．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:38
+#: ../../1.3_choreonoid_createmotion.rst:38
 msgid ""
 "(英語版) \"File\" --> \"Open\" --> \"Pose Sequence\" --> Choose "
 "GR001SampleMotion1.pseq"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:40
+#: ../../1.3_choreonoid_createmotion.rst:40
 msgid "(日本語版) \"ファイル\" --> \"読み込み\" --> \"ポーズ列\" --> Choose GR001SampleMotion1.pseq"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:42
+#: ../../1.3_choreonoid_createmotion.rst:42
 msgid ""
 "もし上記手順でファイルが見えない場合，ファイルは以下に在る． "
 "`./demo/Choreonoid-1.1/share/projects/GR001SampleMotion1.pseq`"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:44
+#: ../../1.3_choreonoid_createmotion.rst:44
 msgid ""
 "選択したファイルに記述されるモーションが，`Choreonoid` 上の左側のペインに表示されるはずなのでそれをクリックして選択 (下図参照)．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:48
+#: ../../1.3_choreonoid_createmotion.rst:48
 msgid ""
 "`Choreonoid` 上の \"PoseRoll\" ペイン上でカーソル (時間軸上に細い縦線で表示される) "
 "を，今回動作を追加する時点に移動．例えば既存のモーションの最後とする．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:50
+#: ../../1.3_choreonoid_createmotion.rst:50
 msgid "ロボットのペインを右クリックし，\"Edit Mode\"／\"編集モード\" に変更．これによりロボットのパーツを動かすことができるようになる．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:52
+#: ../../1.3_choreonoid_createmotion.rst:52
 msgid "ロボットのパーツを好きなように動かす．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:54
+#: ../../1.3_choreonoid_createmotion.rst:54
 msgid "\"PoseRoll\" ペインの \"Insert\"／\"現在姿勢の記憶\" をクリック．新たに追加された動作部分が赤く表示される．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:56
+#: ../../1.3_choreonoid_createmotion.rst:56
 msgid "保存を忘れずに．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:60
+#: ../../1.3_choreonoid_createmotion.rst:60
 msgid "ファイルを保存し，作業を終えたら，`Choreonoid` は終了して良い．"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:68
+#: ../../1.3_choreonoid_createmotion.rst:68
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<1.4_callmotion_byvoice.html>`__ |"
 msgstr ""
 
-#: ..\..\1.3_choreonoid_createmotion.rst:70
+#: ../../1.3_choreonoid_createmotion.rst:70
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 

--- a/doc/locale/ja/LC_MESSAGES/1.4_callmotion_byvoice.po
+++ b/doc/locale/ja/LC_MESSAGES/1.4_callmotion_byvoice.po
@@ -11,112 +11,112 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.4_callmotion_byvoice.rst:1
+#: ../../1.4_callmotion_byvoice.rst:1
 msgid "**(デモ 4) 音声命令によるモーションの再生 (OpenHRI，Choreonoid)**"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:11
+#: ../../1.4_callmotion_byvoice.rst:11
 msgid "このページで体験すること"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:13
+#: ../../1.4_callmotion_byvoice.rst:13
 msgid "音声命令により `Choreonoid` 上のロボットのモーションを再生する．"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:16
+#: ../../1.4_callmotion_byvoice.rst:16
 msgid "関連するチュートリアル"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:17
+#: ../../1.4_callmotion_byvoice.rst:17
 msgid "当ページでは最低限の操作方法のみ紹介します．`Choreonoid` や関連する `RTC` に関する詳細は下記リンクを参照ください．"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:19
+#: ../../1.4_callmotion_byvoice.rst:19
 msgid "`Choreonoid` 上のロボットの腕を音声で上下する \"腕上げロボット\" サンプルについては[3_]"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:20
+#: ../../1.4_callmotion_byvoice.rst:20
 msgid ""
 "`Choreonoid` 上のロボットを `OpenRTM` 経由で操作するための RTC `RobotMotionRtc` に関しては[1_]"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:21
+#: ../../1.4_callmotion_byvoice.rst:21
 msgid ""
 "今回用いるモデルで再現されるロボット `G-ROBOTS GR-001` を用いた `Choreonoid` のスタートアップガイドは[2_]"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:26
+#: ../../1.4_callmotion_byvoice.rst:26
 msgid "SystemEnvironment"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:27
+#: ../../1.4_callmotion_byvoice.rst:27
 msgid "Windows 7／ 8"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:28
+#: ../../1.4_callmotion_byvoice.rst:28
 msgid "マイクが Windows に認識されていること"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:33
+#: ../../1.4_callmotion_byvoice.rst:33
 msgid "HowToRun"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:34
+#: ../../1.4_callmotion_byvoice.rst:34
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:51
+#: ../../1.4_callmotion_byvoice.rst:51
 msgid ""
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\" "
 "の順に，下記リンクをクリックして実行．クリックして動作していなそうな場合，Explorer で \"./demo/0 SpeechDemo\" "
 "を開いてそれぞれ実行．"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:61
+#: ../../1.4_callmotion_byvoice.rst:61
 msgid ""
 "(Optional) デバッグ用途として，`./demo/SampleWordLogger` 内の 0 から 2 までの `.bat` "
 "ファイルを実行しても良い．発話内容を記録する RTC である．"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:63
+#: ../../1.4_callmotion_byvoice.rst:63
 msgid ""
 "このときの RTC の連結状況を `RT System Editor` で表示 (SampleWordLogger "
 "を実行しなかった場合は，`SampleWordLogger0` RTC が無くなるのみ):"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:67
+#: ../../1.4_callmotion_byvoice.rst:67
 msgid "マイクに向かって \"みぎ あげて\" (スペースは0.5秒程度間を空ける) と発話．うまく認識されると，ロボットが右手を上げる．"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:69
+#: ../../1.4_callmotion_byvoice.rst:69
 msgid "他に可能な組み合わせは"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:71
+#: ../../1.4_callmotion_byvoice.rst:71
 msgid "みぎ|ひだり"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:73
+#: ../../1.4_callmotion_byvoice.rst:73
 msgid "`+`"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:75
+#: ../../1.4_callmotion_byvoice.rst:75
 msgid "あげて|さげて|あげない|さげない"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:77
+#: ../../1.4_callmotion_byvoice.rst:77
 msgid "\"さいせい よろしく\" と発話．うまく認識されると，定義済の `SampleMotion1` に従ってロボットが動き出す．"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:79
+#: ../../1.4_callmotion_byvoice.rst:79
 msgid "終了時は，\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" の順に実行．"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:90
+#: ../../1.4_callmotion_byvoice.rst:90
 msgid "管理されているロボット状態"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:91
+#: ../../1.4_callmotion_byvoice.rst:91
 msgid ""
 "(次のチュートリアル[4_]のトピックですが) 当デモは `SEAT` "
 "というモジュールを用いて状態を管理しています．当デモが管理する状態は，`./demo/MotionByVoiceDemo/motion_cnoid.seatml`"
@@ -124,25 +124,25 @@ msgid ""
 "といった，各腕の位置の組合せによる四種類です．"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:106
+#: ../../1.4_callmotion_byvoice.rst:106
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<1.5_modifystate_seatsat.html>`__ |"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:108
+#: ../../1.4_callmotion_byvoice.rst:108
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:37
+#: ../../1.4_callmotion_byvoice.rst:37
 msgid "Run Common Tools"
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:38
+#: ../../1.4_callmotion_byvoice.rst:38
 msgid "In case they are not running."
 msgstr ""
 
-#: ..\..\1.4_callmotion_byvoice.rst:49
+#: ../../1.4_callmotion_byvoice.rst:49
 msgid "Run This Tutorial"
 msgstr ""
 

--- a/doc/locale/ja/LC_MESSAGES/1.5_modifystate_seatsat.po
+++ b/doc/locale/ja/LC_MESSAGES/1.5_modifystate_seatsat.po
@@ -11,113 +11,118 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.5_modifystate_seatsat.rst:1
+#: ../../1.5_modifystate_seatsat.rst:1
 msgid "**(デモ 5) 状態遷移モデル変更による，新たなモーション実行 (SEATSAT)**"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:11
+#: ../../1.5_modifystate_seatsat.rst:11
 msgid "このページで体験すること"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:13
+#: ../../1.5_modifystate_seatsat.rst:13
 msgid ""
 "SEATSAT が管理するロボットの状態遷移に新たな状態を追加し，音声命令によりその状態へ遷移して `Choreonoid` "
 "上のロボットのモーションを再生する．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:16
+#: ../../1.5_modifystate_seatsat.rst:16
 msgid "関連するチュートリアル"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:17
+#: ../../1.5_modifystate_seatsat.rst:17
 msgid ""
 "当ページでは最低限の操作方法のみ紹介します．`SEAT (Speech Event Action Transfer)` "
 "の一般的情報については下記リンクを参照ください．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:19
+#: ../../1.5_modifystate_seatsat.rst:19
 msgid "`SEAT` 含む対話マネージャの書式について[1_]"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:22
+#: ../../1.5_modifystate_seatsat.rst:22
 msgid "動作環境"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:23
+#: ../../1.5_modifystate_seatsat.rst:23
 msgid ""
 "`前チュートリアルの動作環境 <1.4_callmotion_byvoice.html#SystemEnvironment>`__ を満たす．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:26
+#: ../../1.5_modifystate_seatsat.rst:26
 msgid "実行方法"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:27
+#: ../../1.5_modifystate_seatsat.rst:27
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:33
+#: ../../1.5_modifystate_seatsat.rst:33
 msgid ""
 "まず，新たなロボットの状態を既に用意してあり，デモで体験しましょう．`前チュートリアル "
 "<1.4_callmotion_byvoice.html#SystemEnvironment>`__ を再び利用します．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:35
+#: ../../1.5_modifystate_seatsat.rst:35
 msgid ""
 "`./demo/MotionByVoiceDemo` の \"0_StartDemo2.bat\" (前回使った \"0_StartDemo.bat\""
 " ではなく) を実行．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:43
+#: ../../1.5_modifystate_seatsat.rst:43
 msgid "\"1 ConnectRTC.bat\", \"2 ActivateRTC.bat\" を実行．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:52
+#: ../../1.5_modifystate_seatsat.rst:52
 msgid ""
 "\"さいせい よろしく\" と発話．前回と違い今回は，ロボットはおじぎをして手を下げる．なお `Choreonoid` "
 "画面上では見えないが，`SEAT` の管理するロボットの状態は `dance_ready` という新たな状態に移っている．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:54
+#: ../../1.5_modifystate_seatsat.rst:54
 msgid "\"さいせい よろしく\" コマンドは，既存のどのロボット状態からでも有効です; (例．右手だけ上がった状態)"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:56
+#: ../../1.5_modifystate_seatsat.rst:56
 msgid ""
 "\"あくしょん よろしく\" と発話．ロボットは前回のチュートリアルで見せたのと同じダンスをする．その後 `both_down` 状態 (初期の状態) "
 "に戻る．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:58
+#: ../../1.5_modifystate_seatsat.rst:58
 msgid "終了時は，\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" の順に実行．"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:69
+#: ../../1.5_modifystate_seatsat.rst:69
 msgid "新規状態の追加方法"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:70
+#: ../../1.5_modifystate_seatsat.rst:70
 msgid "状態を追加するために今回追加したのは次の箇所::"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:92
+#: ../../1.5_modifystate_seatsat.rst:92
 msgid "また，`あくしょん` という新たな語を音声認識させるために，`Julius` の設定ファイルも次のように更新::"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:116
+#: ../../1.5_modifystate_seatsat.rst:116
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:31
+#: ../../1.5_modifystate_seatsat.rst:31
 msgid ""
 "For starting necessary services, quickly go [run-common-tools_] and come "
 "back."
 msgstr ""
 
-#: ..\..\1.5_modifystate_seatsat.rst:114
+#: ../../1.5_modifystate_seatsat.rst:114
 msgid ""
-"Go back to `index <top.html>`__ | Go to `next <1.6_scararobot_control>`__ |"
+"Go back to `index <top.html>`__ | Go to `next "
+"<1.6_scararobot_control.html>`__ |"
 msgstr ""
+
+#~ msgid ""
+#~ "Go back to `index <top.html>`__ | Go to `next <1.6_scararobot_control>`__ |"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Go back to `index <top.html>`__ | Go to `next <2.1_samplewordlogger.html>`__"

--- a/doc/locale/ja/LC_MESSAGES/1.6_scararobot_control.po
+++ b/doc/locale/ja/LC_MESSAGES/1.6_scararobot_control.po
@@ -11,438 +11,438 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\1.6_scararobot_control.rst:1
+#: ../../1.6_scararobot_control.rst:1
 msgid "**(デモ 6) アカデミック スカラロボットの制御 **"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:11
+#: ../../1.6_scararobot_control.rst:11
 msgid "Introduction"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:14
+#: ../../1.6_scararobot_control.rst:14
 msgid "このページで体験すること"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:15
+#: ../../1.6_scararobot_control.rst:15
 msgid "アカデミック スカラロボットの制御　ver.1.1"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:18
+#: ../../1.6_scararobot_control.rst:18
 msgid "動作環境"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:19
+#: ../../1.6_scararobot_control.rst:19
 msgid "Windows 7 / 8"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:20
+#: ../../1.6_scararobot_control.rst:20
 msgid "Internet Explorer (IE) 8 / 10"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:21
+#: ../../1.6_scararobot_control.rst:21
 msgid "ヴイストン株式会社製 アカデミック スカラロボット（VS-ASR） [1_]"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:24
+#: ../../1.6_scararobot_control.rst:24
 msgid "実行方法"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:25
+#: ../../1.6_scararobot_control.rst:25
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:28
+#: ../../1.6_scararobot_control.rst:28
 msgid "nameserver 起動 (全チュートリアル共通)"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:29
+#: ../../1.6_scararobot_control.rst:29
 msgid "基本的に `OpenRTM` の `nameserver` は一度起動すると，起動したままでもすべてのチュートリアルは動作すると思われます．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:31
+#: ../../1.6_scararobot_control.rst:31
 msgid "次のリンクをクリックして `nameserver` を起動．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:39
+#: ../../1.6_scararobot_control.rst:39
 msgid ""
 "（上記方法でうまく行かなかった場合のみ以降実施） `Explorer` で `demo` フォルダを開き，`rtm-naming.bat` "
 "をダブルクリックして実行．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:41
+#: ../../1.6_scararobot_control.rst:41
 msgid "`cmd.exe` (Command prompt) が開きっぱなしになり，次のような文言が表示されれば成功．::"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:47
+#: ../../1.6_scararobot_control.rst:47
 msgid "上記手順で `cmd.exe` が消えてしまう場合は，`nameserver` がうまく起動していないので次の手順で原因を発見："
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:49
+#: ../../1.6_scararobot_control.rst:49
 msgid "3.1) `Explorer` 上で，USB のドライブ名を確認 (D/E/F etc. ここでは `F` と仮定)"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:51
+#: ../../1.6_scararobot_control.rst:51
 msgid "3.2) `cmd.exe` を手動起動 (Win 7: [2_], Win 8: [3_])"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:53
+#: ../../1.6_scararobot_control.rst:53
 msgid "3.3) 以下コマンドでフォルダ移動・コマンド実行::"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:59
+#: ../../1.6_scararobot_control.rst:59
 msgid ""
 "エラー等発生していればここで表示されるのでその内容を診断．`OpenRTM` の `nameserver` の問題は WEB "
 "で検索して対処してみてください．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:62
+#: ../../1.6_scararobot_control.rst:62
 msgid "チュートリアルのプログラム実行"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:64
+#: ../../1.6_scararobot_control.rst:64
 msgid ""
 "次のリンクをクリックして `./demo/ScaraRobotDemo/0_StartDemo.bat` を実行する．起動できない場合は，手動で "
 "`Explorer` から実行する．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:70
+#: ../../1.6_scararobot_control.rst:70
 msgid "なお，スカラロボットの座標系は図1に示す通りである．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:74
+#: ../../1.6_scararobot_control.rst:74
 msgid "図1　スカラロボットの座標系"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:76
+#: ../../1.6_scararobot_control.rst:76
 msgid "次のリンクをクリックして `./misc/VstoneScaraRobotRTC/Sample.csv` を編集する．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:82
+#: ../../1.6_scararobot_control.rst:82
 msgid "なお，スカラロボットで使用可能なコマンドは表1に示す通りである．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:84
+#: ../../1.6_scararobot_control.rst:84
 msgid "表1　スカラロボットで使用可能なコマンド"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:87
+#: ../../1.6_scararobot_control.rst:87
 msgid "No."
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:87
+#: ../../1.6_scararobot_control.rst:87
 msgid "コマンド"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:87
+#: ../../1.6_scararobot_control.rst:87
 msgid "書式"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:87 ..\..\1.6_scararobot_control.rst:133
+#: ../../1.6_scararobot_control.rst:87 ../../1.6_scararobot_control.rst:133
 msgid "説明"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:89
+#: ../../1.6_scararobot_control.rst:89
 msgid "1"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:89 ..\..\1.6_scararobot_control.rst:89
+#: ../../1.6_scararobot_control.rst:89 ../../1.6_scararobot_control.rst:89
 msgid "SERVO_OFF"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:89
+#: ../../1.6_scararobot_control.rst:89
 msgid "全軸サーボをOFFにする．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:91
+#: ../../1.6_scararobot_control.rst:91
 msgid "2"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:91 ..\..\1.6_scararobot_control.rst:91
+#: ../../1.6_scararobot_control.rst:91 ../../1.6_scararobot_control.rst:91
 msgid "SERVO_ON"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:91
+#: ../../1.6_scararobot_control.rst:91
 msgid "全軸サーボをONにする．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:93
+#: ../../1.6_scararobot_control.rst:93
 msgid "3"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:93 ..\..\1.6_scararobot_control.rst:93
+#: ../../1.6_scararobot_control.rst:93 ../../1.6_scararobot_control.rst:93
 msgid "HAND_CLOSE"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:93
+#: ../../1.6_scararobot_control.rst:93
 msgid "ハンドを完全に閉じる．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:95
+#: ../../1.6_scararobot_control.rst:95
 msgid "4"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:95 ..\..\1.6_scararobot_control.rst:95
+#: ../../1.6_scararobot_control.rst:95 ../../1.6_scararobot_control.rst:95
 msgid "HAND_OPEN"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:95
+#: ../../1.6_scararobot_control.rst:95
 msgid "ハンドを完全に開く．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:97
+#: ../../1.6_scararobot_control.rst:97
 msgid "5"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:97
+#: ../../1.6_scararobot_control.rst:97
 msgid "HAND_MOV"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:97
+#: ../../1.6_scararobot_control.rst:97
 msgid "HAND_MOV，Rate（単位：Rate [%]）"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:97
+#: ../../1.6_scararobot_control.rst:97
 msgid "ハンドを指定した開閉角度に動作させる．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:99
+#: ../../1.6_scararobot_control.rst:99
 msgid "6"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:99
+#: ../../1.6_scararobot_control.rst:99
 msgid "CMVS"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:99
+#: ../../1.6_scararobot_control.rst:99
 msgid "CMVS，X，Y，Z，Rz（単位：X，Y，Z [m]，Rz [rad]）"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:99
+#: ../../1.6_scararobot_control.rst:99
 msgid "ロボット座標系の絶対値で指定された目標位置に対し，直交空間における直線補間で動作させる．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:101
+#: ../../1.6_scararobot_control.rst:101
 msgid "7"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:101
+#: ../../1.6_scararobot_control.rst:101
 msgid "CMOV"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:101
+#: ../../1.6_scararobot_control.rst:101
 msgid "CMOV，X，Y，Z，Rz（単位：X，Y，Z [m]，Rz [rad]）"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:101
+#: ../../1.6_scararobot_control.rst:101
 msgid "ロボット座標系の絶対値で指定された目標位置に対し，関節空間における直線補間で動作させる．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:103
+#: ../../1.6_scararobot_control.rst:103
 msgid "8"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:103
+#: ../../1.6_scararobot_control.rst:103
 msgid "JMOV"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:103
+#: ../../1.6_scararobot_control.rst:103
 msgid "JMOV，J1，J2，J3，J4（単位：J1，J2，J4 [rad]，J3 [m]）"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:103
+#: ../../1.6_scararobot_control.rst:103
 msgid "関節座標系の絶対値で指定された目標位置に対し，関節空間における直線補間で動作させる．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:106
+#: ../../1.6_scararobot_control.rst:106
 msgid "次のリンクをクリックして `./demo/RTSE.bat` を実行する．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:112
+#: ../../1.6_scararobot_control.rst:112
 msgid "RT System Editor が図2のように起動する．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:116
+#: ../../1.6_scararobot_control.rst:116
 msgid "図2　RT System Editor"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:118
+#: ../../1.6_scararobot_control.rst:118
 msgid ""
 "左側のペインで 127.0.0.1 を選択し，直上の右矢印をクリックすると，起動中の RT Component が同ペイン上に表示される．ここでは "
 "`ScaraRobotControlRTC` ， `VS_ASR_RTC` となるはず．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:120
+#: ../../1.6_scararobot_control.rst:120
 msgid ""
 "File --> Open New System Editor を選ぶと， `System Diagram` "
 "が真ん中のペインに開かれる．左側のペインから各 RTC を System Diagram にドラッグすると図3のように表示される．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:124
+#: ../../1.6_scararobot_control.rst:124
 msgid "図3　RTC を配置した RT System Editor"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:126
+#: ../../1.6_scararobot_control.rst:126
 msgid "同ペイン上で各 RTC を接続する．上に挙げた2つの RTC を接続する．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:128
+#: ../../1.6_scararobot_control.rst:128
 msgid ""
 "同ペイン内の`ScaraRobotControlRTC`をクリックし，直下にある“Configuration” というタブ内の "
 "Configuration 値を編集する．各 Configuration 値の詳細は表2に示す通りである．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:130
+#: ../../1.6_scararobot_control.rst:130
 msgid "表2　ScaraRobotControlRTCのコンフィギュレーション"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:133
+#: ../../1.6_scararobot_control.rst:133
 msgid "名前"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:133
+#: ../../1.6_scararobot_control.rst:133
 msgid "デフォルト値"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:135
+#: ../../1.6_scararobot_control.rst:135
 msgid "BaseOffsetX"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:135 ..\..\1.6_scararobot_control.rst:137
+#: ../../1.6_scararobot_control.rst:135 ../../1.6_scararobot_control.rst:137
 msgid "0.0"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:135
+#: ../../1.6_scararobot_control.rst:135
 msgid "ベースオフセットのX軸方向の値を[m]で指定．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:137
+#: ../../1.6_scararobot_control.rst:137
 msgid "BaseOffsetY"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:137
+#: ../../1.6_scararobot_control.rst:137
 msgid "ベースオフセットのY軸方向の値を[m]で指定．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:139
+#: ../../1.6_scararobot_control.rst:139
 msgid "FilePass"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:139
+#: ../../1.6_scararobot_control.rst:139
 msgid "Sample.csv"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:139
+#: ../../1.6_scararobot_control.rst:139
 msgid "読み込むcsvファイルが保存されている場所までのパスを指定．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:141
+#: ../../1.6_scararobot_control.rst:141
 msgid "Speed"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:141
+#: ../../1.6_scararobot_control.rst:141
 msgid "30"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:141
+#: ../../1.6_scararobot_control.rst:141
 msgid "ロボットの動作速度を1[%]～100[%]の整数値で指定．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:144
+#: ../../1.6_scararobot_control.rst:144
 msgid "同ペイン上で直上左にある“ALL”というアイコンをクリック，すべての RTC を activate (参考リンク 1_)．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:148
+#: ../../1.6_scararobot_control.rst:148
 msgid "図4　RT System Editor における RTC の Activate"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:150
+#: ../../1.6_scararobot_control.rst:150
 msgid ""
 "手順5～8を一括して行うスクリプト `./demo/ScaraRobotDemo/8_ConnectRTC.bat` は以下に用意してあります．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:156
+#: ../../1.6_scararobot_control.rst:156
 msgid "`ScaraRobotControlRTC` のコマンドプロンプトで `s` キーを入力すると，ロボットが動作を開始する．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:160
+#: ../../1.6_scararobot_control.rst:160
 msgid "図5 ScaraRobotControlRTC"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:162
+#: ../../1.6_scararobot_control.rst:162
 msgid ""
 "`VS_ASR_RTC0` のコマンドプロンプトには，実行しているコマンドのステータスが表示されます（例：関節角リミットオーバーでエラー停止した状態）．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:166
+#: ../../1.6_scararobot_control.rst:166
 msgid "図6　関節角リミットオーバーでエラー停止した状態"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:168
+#: ../../1.6_scararobot_control.rst:168
 msgid "終了するには，次の手順で \"RTC を inactivate\" --> \"RTC 間のリンクを切り離し\" --> \"各 RTC を停止\" を行う．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:170
+#: ../../1.6_scararobot_control.rst:170
 msgid "同ペイン上で直上左にある \"All Deactivate\" というアイコンをクリック"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:171
+#: ../../1.6_scararobot_control.rst:171
 msgid "手順6で行ったのと逆を行う．つまり，各接続線上で右クリックし\"切断\"を選択．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:172
+#: ../../1.6_scararobot_control.rst:172
 msgid "手順1で起動したコマンドプロンプト群を手動で終了．ただし `rtm-naming.bat` のそれは停止せずとも良い．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:174
+#: ../../1.6_scararobot_control.rst:174
 msgid "※手順11を一括して行うスクリプトは以下に用意してある．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:180
+#: ../../1.6_scararobot_control.rst:180
 msgid "関節角リミットオーバーでエラー停止した状態からの復帰方法"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:182
+#: ../../1.6_scararobot_control.rst:182
 msgid "12.1) 関節角リミットオーバーでエラーを出力して停止している状態である．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:186
+#: ../../1.6_scararobot_control.rst:186
 msgid "図7　復帰方法 1"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:188
+#: ../../1.6_scararobot_control.rst:188
 msgid ""
 "12.2) "
 "まず，ScaraRobotControlRTCの上にカーソルを持っていき，右クリックでプルダウンメニューを出し，その中のResetを選択する．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:192
+#: ../../1.6_scararobot_control.rst:192
 msgid "図8　復帰方法 2"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:194
+#: ../../1.6_scararobot_control.rst:194
 msgid "12.3) Reset後は下図のような状態になる．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:198
+#: ../../1.6_scararobot_control.rst:198
 msgid "図9　復帰方法 3"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:200
+#: ../../1.6_scararobot_control.rst:200
 msgid ""
 "12.4) RTC 以外の System Diagram 上で右クリックによりプルダウンメニューを出し，All Activate "
 "を選択する．これで最初の状態に戻る．"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:204
+#: ../../1.6_scararobot_control.rst:204
 msgid "図10　復帰方法 4"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:214
+#: ../../1.6_scararobot_control.rst:214
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next <2.1_samplewordlogger.html>`__"
 " |"
 msgstr ""
 
-#: ..\..\1.6_scararobot_control.rst:216
+#: ../../1.6_scararobot_control.rst:216
 msgid "Choose `Other language <index.html>`__"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/2.1_samplewordlogger.po
+++ b/doc/locale/ja/LC_MESSAGES/2.1_samplewordlogger.po
@@ -11,219 +11,219 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\2.1_samplewordlogger.rst:1
+#: ../../2.1_samplewordlogger.rst:1
 msgid "**(RTC 作成 1) 音声キーワードロガー RTC の開発**"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:12
+#: ../../2.1_samplewordlogger.rst:12
 msgid "Introduction"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:15
+#: ../../2.1_samplewordlogger.rst:15
 msgid "このページで体験すること"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:17
+#: ../../2.1_samplewordlogger.rst:17
 msgid ""
 "`OpenHRI` の RTC と接続することで，音声認識されたキーワードのログを取得し，時刻とともにファイルに保存する "
 "`SampleWordLogger RTC` の開発"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:20
+#: ../../2.1_samplewordlogger.rst:20
 msgid "関連するチュートリアル"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:21
+#: ../../2.1_samplewordlogger.rst:21
 msgid ""
 "`RTC` 作成の一般的作業の詳細は SampleWordLogger コンポーネントのチュートリアル[1_]に記述があります．特に `Eclipse`"
 " 上での GUI を利用した開発が説明されています． - "
 "なお本チュートリアル内で，[1_]内の多くの画像を参照しています．参照元はその都度記載しています．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:25
+#: ../../2.1_samplewordlogger.rst:25
 msgid "SystemEnvironment"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:26
+#: ../../2.1_samplewordlogger.rst:26
 msgid "Windows 7 / 8"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:27
+#: ../../2.1_samplewordlogger.rst:27
 msgid "Visual C++ 2010 (English [3_], Japanese [4_])"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:28
+#: ../../2.1_samplewordlogger.rst:28
 msgid ""
 "`CMake` 2.8 (インストーラが同梱されています ./misc/installer/cmake-2.8.8-win32-x86.exe)"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:29
+#: ../../2.1_samplewordlogger.rst:29
 msgid "`RTCBuilder` 1.1 (bundled in Eclipse [5_])"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:33
+#: ../../2.1_samplewordlogger.rst:33
 msgid "RTC の仕様 (I/O, Configuration)"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:35
+#: ../../2.1_samplewordlogger.rst:35
 msgid "これから作成するコンポーネントを SampleWordLogger RTC と呼ぶことにします．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:37
+#: ../../2.1_samplewordlogger.rst:37
 msgid ""
 "このコンポーネントは `TimedString` 型の入力ポート (`InPort`) を持ちます．今回はログをファイルへ出力するのみとし，`RTC` "
 "として出力ポート (`OutPort`) は持たないｋとにします．`InPort` 名を `result` とします．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:39
+#: ../../2.1_samplewordlogger.rst:39
 msgid "ログファイルの場所は今回はハードコードします (お好みに変えて下さい)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:41
+#: ../../2.1_samplewordlogger.rst:41
 msgid "上から RTC の仕様を次のようにまとめます．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:44
+#: ../../2.1_samplewordlogger.rst:44
 msgid "Component Name"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:44
+#: ../../2.1_samplewordlogger.rst:44
 msgid "SampleWordLogger"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:46
+#: ../../2.1_samplewordlogger.rst:46
 msgid "InPort"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:48 ..\..\2.1_samplewordlogger.rst:54
+#: ../../2.1_samplewordlogger.rst:48 ../../2.1_samplewordlogger.rst:54
 msgid "Port Name"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:48
+#: ../../2.1_samplewordlogger.rst:48
 msgid "result"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:50 ..\..\2.1_samplewordlogger.rst:56
-#: ..\..\2.1_samplewordlogger.rst:62
+#: ../../2.1_samplewordlogger.rst:50 ../../2.1_samplewordlogger.rst:56
+#: ../../2.1_samplewordlogger.rst:62
 msgid "Data Type"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:50
+#: ../../2.1_samplewordlogger.rst:50
 msgid "TimedString"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:52
+#: ../../2.1_samplewordlogger.rst:52
 msgid "OutPort"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:54 ..\..\2.1_samplewordlogger.rst:56
-#: ..\..\2.1_samplewordlogger.rst:60 ..\..\2.1_samplewordlogger.rst:62
-#: ..\..\2.1_samplewordlogger.rst:64
+#: ../../2.1_samplewordlogger.rst:54 ../../2.1_samplewordlogger.rst:56
+#: ../../2.1_samplewordlogger.rst:60 ../../2.1_samplewordlogger.rst:62
+#: ../../2.1_samplewordlogger.rst:64
 msgid "(None)"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:58
+#: ../../2.1_samplewordlogger.rst:58
 msgid "Configuration"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:60
+#: ../../2.1_samplewordlogger.rst:60
 msgid "Parameter Name"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:64
+#: ../../2.1_samplewordlogger.rst:64
 msgid "Values"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:69
+#: ../../2.1_samplewordlogger.rst:69
 msgid "RTCBuilder のインストール，起動"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:70
+#: ../../2.1_samplewordlogger.rst:70
 msgid ""
 "本章では `Eclipse` ベースのツール `OpenRTP (Open RT Platform)` に同梱される `RTBuilder` "
 "を利用するので，[2_]からダウンロード・インストールして下さい．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:72
+#: ../../2.1_samplewordlogger.rst:72
 msgid ""
 "新規ワークスペースを指定して Eclipse を起動すると，以下のような Welcome ページが表示されます (`画像引用元 "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/fig1-1EclipseInit.png>`__)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:76
+#: ../../2.1_samplewordlogger.rst:76
 msgid ""
 "Welcome ページはいまは必要ないので左上の「×」ボタンを押して閉じてください (`画像引用元 "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/fig2-2PerspectiveSwitch.png>`__)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:80
+#: ../../2.1_samplewordlogger.rst:80
 msgid ""
 "右上の「Open Perspective」ボタンを押下し，プルダウンの「Other…」 ボタンを押下します(`画像引用元 "
 "<http://www.openrtm.org/openrtm/sites/default/files/208/fig2-3PerspectiveSelection.png>`__)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:84
+#: ../../2.1_samplewordlogger.rst:84
 msgid "`RTC Builder` を選択することで，RTCBuilder が起動します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:88
+#: ../../2.1_samplewordlogger.rst:88
 msgid "How to make RTC"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:91
+#: ../../2.1_samplewordlogger.rst:91
 msgid "新規プロジェクトの作成"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:92
+#: ../../2.1_samplewordlogger.rst:92
 msgid ""
 "SampleWordLogger コンポーネントを作成するために，`RTCBuilder` で新規プロジェクトを "
 "作成する必要が有ります．画面上部のメニューから[ファイル]－[新規]－ [プロジェクト]を選択します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:96
+#: ../../2.1_samplewordlogger.rst:96
 msgid ""
 "表示された ｢新規プロジェクト｣ 画面において，｢その他｣－｢RTCビルダ｣ を選択し，｢次へ｣ "
 "をクリックします．｢プロジェクト名｣欄に作成するプロジェクト名 (ここでは SampleWordLogger) を入力して｢終了｣をクリックします．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:100
+#: ../../2.1_samplewordlogger.rst:100
 msgid ""
 "指定した名称のプロジェクトが生成され，パッケージエクスプローラ内に追加されます． 生成したプロジェクト内には，デフォルト値が設定された RTC プロファ"
 " イル XML(RTC.xml) が自動的に生成されるのがわかると思います．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:104
+#: ../../2.1_samplewordlogger.rst:104
 msgid ""
 "`RTC.xml` が生成された時点で，このプロジェクトに関連付けられているワークスペースとして `RTCBuilder` "
 "のエディタが開くはずです．もし開かない場合は，ツールバーの｢Open New RtcBuilder Editor｣ボタンを押下するか，メニューバーの "
 "[file]-[Open New Builder Editor] を選択します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:108
+#: ../../2.1_samplewordlogger.rst:108
 msgid ""
 "(`画像引用元 "
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/fig2-10FileMenuOpenNewBuilder.png>`__)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:113
+#: ../../2.1_samplewordlogger.rst:113
 msgid "SampleWordLogger コンポーネントの雛型の生成"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:115
+#: ../../2.1_samplewordlogger.rst:115
 msgid "SampleWordLogger RTC の雛型の生成は，`OpenRTP` に同梱の `RTCBuilder` を用いて行います．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:118
+#: ../../2.1_samplewordlogger.rst:118
 msgid "プロファイル情報入力とコードの生成"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:119
+#: ../../2.1_samplewordlogger.rst:119
 msgid ""
 "まず，いちばん左の「基本」タブを選択し，基本情報を入力します．先ほ ど決めた SampleWordLogger "
 "コンポーネントの仕様(名前)の他に，概要やバージョン等を入力してください．ラベルが赤字の項目は必須項目です．その他はデフォルトで構いません．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:123
+#: ../../2.1_samplewordlogger.rst:123
 msgid ""
 "次に，「アクティビティ」タブを選択し，使用するアクションコールバッ クを指定します． `SampleWordLogger RTC` "
 "では，onActivated(), onDeactivated(), onExecute() コールバックを使用します．下図のように (1) の "
@@ -232,86 +232,86 @@ msgid ""
 "<http://www.openrtm.org/openrtm/sites/default/files/1431/Activity.png>`__)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:128
+#: ../../2.1_samplewordlogger.rst:128
 msgid ""
 "さらに，\"Data Ports\" タブを選択し，データポートの情報を入力します． "
 "先ほど決めた仕様を元に以下のように入力します．なお，変数名や表示位置はオプションで，そのままで結構です．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:132
+#: ../../2.1_samplewordlogger.rst:132
 msgid ""
 "次に，「言語・環境」タブを選択し，プログラミング言語を選択します． ここでは，`C++` を選択します．なお，言語・環境はデフォルト等が "
 "設定されておらず，指定し忘れるとコード生成時にエラーになりますので， 必ず言語の指定を行うようにしてください．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:134
+#: ../../2.1_samplewordlogger.rst:134
 msgid ""
 "また，`C++` の場合デフォルトでは `CMake` を利用してビルドすることになって いますが，旧式の `VC` "
 "のプロジェクトやソリューションを直接 `RTCBuilder` が 生成する方法を利用したい場合は `Use old build "
 "environment` を チェックしてください．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:136
+#: ../../2.1_samplewordlogger.rst:136
 msgid "最後に，「基本」タブにある\"コード生成\"ボタンをクリックし，コンポー ネントの雛型を生成します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:138
+#: ../../2.1_samplewordlogger.rst:138
 msgid ""
 "※ 生成されるコード群は，eclipse 起動時に指定したワークスペースフォルダの中に生成されます．現在のワークスペースは，「ファイル(F)」 > "
 "「ワークスペースの切り替え(W)...」で確認することができます．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:141
+#: ../../2.1_samplewordlogger.rst:141
 msgid "仮ビルド"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:143
+#: ../../2.1_samplewordlogger.rst:143
 msgid ""
 "さて，ここまでで SampleWordLogger コンポーネントのソースコードが生成されました． 処理の中身は実装されていないので，`InPort` "
 "に他の `RTC` を接続しても何も出力されませんが，生成直後のソースコードだけでもコンパイルおよび実行はできます．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:145
+#: ../../2.1_samplewordlogger.rst:145
 msgid "※サービスポートとプロバイダを持つコンポーネントの場合，実装を行わないとビルドが通らないものもあります．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:147
+#: ../../2.1_samplewordlogger.rst:147
 msgid ""
 "では，まず `CMake` を利用してビルド環境の `Configure` を行います．Linuxで あれば，SampleWordLogger "
 "コンポーネントのソースが生成されたディレクトリで::"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:152
+#: ../../2.1_samplewordlogger.rst:152
 msgid ""
 "とすれば，Configureおよびビルドが完了するはずです．`Windows` の場合は GUI を利用して `Configure` してみます． "
 "スタートメニューなどから `CMake (cmake-gui)` を起動します(`画像引用元 "
 "<http://www.openrtm.org/openrtm/sites/default/files/4625/CMakeGUI0.png>`__)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:156
+#: ../../2.1_samplewordlogger.rst:156
 msgid ""
 "画面上部に以下のようなテキストボックスがありますので，それぞれソースコードの場所(`CMakeList.txt` が有る場所) "
 "と，ビルドディレクトリを指定します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:158
+#: ../../2.1_samplewordlogger.rst:158
 msgid "Where is the soruce code ^ Where to build the binaries"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:160
+#: ../../2.1_samplewordlogger.rst:160
 msgid ""
 "ソースコードの場所は SampleWordLogger コンポーネントのソースが生成された場所で `CMakeList.txt` "
 "が存在するディレクトリです．デフォルトでは <ワークス ペースディレクトリ>/SampleWordLogger になります．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:162
+#: ../../2.1_samplewordlogger.rst:162
 msgid ""
 "また，ビルドディレクトリとは，ビルドするためのプロジェクトファイルやオブジェクトファイル，バイナリを格納する場所のことです．場所は任意ですが，この場合 "
 "<ワークスペースディレクトリ>/SampleWordLogger/build のように分かりやすい名前をつけた SampleWordLogger "
 "のサブディレクトリを指定することをお勧めします．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:166
+#: ../../2.1_samplewordlogger.rst:166
 msgid ""
 "指定したら，下の `Configure` "
 "ボタンを押します．すると下図のようなダイアログが表示されますので，生成したいプロジェクトの種類を指定します．今回は `Visual Studio 10`"
@@ -319,48 +319,48 @@ msgid ""
 "<http://www.openrtm.org/openrtm/sites/default/files/4625/CMakeGUI1.png>`__)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:170
+#: ../../2.1_samplewordlogger.rst:170
 msgid ""
 "ダイアログで Finish を押すと Configure が始まります．問題がなければ下部のログウインドウに Configuring done "
 "と出力されますので，続けて Generate ボタンを押します．Generating done "
 "と出ればプロジェクトファイル・ソリューションファイル等の出力が完了します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:172
+#: ../../2.1_samplewordlogger.rst:172
 msgid ""
 "なお，`CMake` は Configure の段階でキャッシュファイルを生成しますので，トラブルなどで設定を変更したり環境を変更した場合は "
 "[File]-[Delete Cache] でキャッシュを削除して `Configure` からやり直してください．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:174
+#: ../../2.1_samplewordlogger.rst:174
 msgid ""
 "次に先ほど指定した `build` ディレクトリの中の SampleWordLogger.sln をダブルクリックして `Visual Studio "
 "2010` を起動します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:176
+#: ../../2.1_samplewordlogger.rst:176
 msgid ""
 "起動後，ソリューションエクスプローラーの `ALL_BUILD` "
 "を右クリックしビルドを選択してビルドします．特に問題がなければ正常にビルドが終了します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:180
+#: ../../2.1_samplewordlogger.rst:180
 msgid "ここで `VC++ 2010` は閉じても構いません．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:183
+#: ../../2.1_samplewordlogger.rst:183
 msgid "ヘッダ，ソースの編集"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:186
+#: ../../2.1_samplewordlogger.rst:186
 msgid "アクティビティ処理の実装"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:187
+#: ../../2.1_samplewordlogger.rst:187
 msgid "SampleWordLogger RTC では，InPort から語を受け取った時刻とその語をファイルストリームに流します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:189
+#: ../../2.1_samplewordlogger.rst:189
 msgid ""
 "`onActivated()`, `onExecute()`, `onDeactivated()` での処理内容を下図に示します (`編集用の図ファイル"
 " "
@@ -368,41 +368,41 @@ msgid ""
 " 必要であれば編集権を同ページ内から申請して下さい)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:194
+#: ../../2.1_samplewordlogger.rst:194
 msgid ".cpp ファイル編集"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:196
+#: ../../2.1_samplewordlogger.rst:196
 msgid "下記のように，`onActivated()`, `onDeactivated()`, `onExecute()` を実装します．::"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:366
+#: ../../2.1_samplewordlogger.rst:366
 msgid "CMakeList.txt の編集"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:368
+#: ../../2.1_samplewordlogger.rst:368
 msgid ""
 "この RTC ではログファイル生成のために `xmllib` を使用しています (実際のログのフォーマットは xml ではありませんが) "
 "ので，`RTCBuilder` が生成した `CMakeLists.txt` にその旨を追記します．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:370
+#: ../../2.1_samplewordlogger.rst:370
 msgid ""
 "適当なエディタ (`VC++ 2010, Emacs` 等) 上で，`SampleWordLogger/CMakeLists.txt` "
 "を開いて下さい．::"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:374
+#: ../../2.1_samplewordlogger.rst:374
 msgid ""
 "とあり，`src` フォルダの情報は移譲されていることが分かるので，`SampleWordLogger/src/CMakeLists.txt` "
 "を開きます．このファイル中を例えば以下の様に変更します::"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:393
+#: ../../2.1_samplewordlogger.rst:393
 msgid "VC++ によるビルド"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:394
+#: ../../2.1_samplewordlogger.rst:394
 msgid ""
 "Visual C++ 2010 に戻ります．もし既に閉じていれば，再度 `SampleWordLogger.sln` "
 "ファイルをダブルクリックし，Visual C++ 2010 を起動します．Visual C++ 2010 "
@@ -410,76 +410,76 @@ msgid ""
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/VC++_build.png>`__)．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:398
+#: ../../2.1_samplewordlogger.rst:398
 msgid "Visual C++ 2010 のコンソールにエラーが起きたと表示されなければ，以上で RTC 作成が終了です．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:402
+#: ../../2.1_samplewordlogger.rst:402
 msgid "実行方法"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:403
+#: ../../2.1_samplewordlogger.rst:403
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:409
+#: ../../2.1_samplewordlogger.rst:409
 msgid ""
 "では実行してみましょう． `SampleWordLogger` は単体だと何も行わないので，先に紹介された `MotionByVoiceDemo` "
 "と組合せて発話を記録してみましょう．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:412
+#: ../../2.1_samplewordlogger.rst:412
 msgid ""
 "上記二つのフォルダからそれぞれに格納される RTC を呼ぶための .bat ファイルを既に "
 "`./demo/MotionByVoiceLoggerDemo` として用意してあります．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:414
+#: ../../2.1_samplewordlogger.rst:414
 msgid "MotionByVoiceLoggerDemo"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:416
+#: ../../2.1_samplewordlogger.rst:416
 msgid ""
 "`./demo/MotionByVoiceLoggerDemo` から "
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\" "
 "の順に，下記リンクをクリックして実行．クリックして動作していなそうな場合，Explorer で当該フォルダを開いてそれぞれ実行．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:432
+#: ../../2.1_samplewordlogger.rst:432
 msgid ""
 "`MotionByVoiceDemo のチュートリアル <1.4_callmotion_byvoice.html#HowToRun>`__ "
 "に従い，発話デモを実行．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:434
+#: ../../2.1_samplewordlogger.rst:434
 msgid ""
 "\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" "
 "の順に実行し，RT システムを停止．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:444
+#: ../../2.1_samplewordlogger.rst:444
 msgid ""
 "`./demo/SampleWordLogger/build/Debug/SampleWord.log` "
 "をテキストエディタで開くと，下の例のように，時刻と発話内容が記録されている．"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:446
+#: ../../2.1_samplewordlogger.rst:446
 msgid ""
 "2014/03/13 08:56:31 左 さげて 2014/03/13 08:56:44 右 あげて 2014/03/13 08:57:08 左 "
 "よろしく 2014/03/13 08:58:23 左 あげて 2014/03/13 08:58:39 左 あげない"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:467
+#: ../../2.1_samplewordlogger.rst:467
 msgid ""
 "Go back to `index <top.html>`__ | Go to `next "
 "<2.2_samplemotionselector.html>`__ |"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:469
+#: ../../2.1_samplewordlogger.rst:469
 msgid "Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\2.1_samplewordlogger.rst:407
+#: ../../2.1_samplewordlogger.rst:407
 msgid ""
 "For starting necessary services, quickly go [run-common-tools_] and come "
 "back."

--- a/doc/locale/ja/LC_MESSAGES/2.2_samplemotionselector.po
+++ b/doc/locale/ja/LC_MESSAGES/2.2_samplemotionselector.po
@@ -11,157 +11,157 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\2.2_samplemotionselector.rst:1
+#: ../../2.2_samplemotionselector.rst:1
 msgid "**(RTC 作成 2) Choreonoid のモーションを選択する RTC の開発**"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:12
+#: ../../2.2_samplemotionselector.rst:12
 msgid "Introduction"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:15
+#: ../../2.2_samplemotionselector.rst:15
 msgid "このページで体験すること"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:17
+#: ../../2.2_samplemotionselector.rst:17
 msgid ""
 "キーボードからの入力によって， Choreonoidのモーションを呼び出すことが出来る `SampleMotionCaller RTC` の開発"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:20
+#: ../../2.2_samplemotionselector.rst:20
 msgid "関連するチュートリアル"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:21
+#: ../../2.2_samplemotionselector.rst:21
 msgid "前章 (Logger RTC 開発)[1_]を終了し，`RTC` のスクラッチからの作成方法を習得していることを前提としています．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:24
+#: ../../2.2_samplemotionselector.rst:24
 msgid "SystemEnvironment"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:25
+#: ../../2.2_samplemotionselector.rst:25
 msgid "前章 (Logger RTC 開発)[1_]に同じ．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:29
+#: ../../2.2_samplemotionselector.rst:29
 msgid "RTC の仕様 (I/O, Configuration)"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:31
+#: ../../2.2_samplemotionselector.rst:31
 msgid "これから作成するコンポーネントを `SampleMotionCaller` RTC と呼ぶことにします．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:33
+#: ../../2.2_samplemotionselector.rst:33
 msgid ""
 "このコンポーネントは，キーボードからの入力を受け付けるので `InPort` は未指定です．入力を解釈した結果を `TimedString` で "
 "`OutPort` へ出力します．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:36
+#: ../../2.2_samplemotionselector.rst:36
 msgid "RTC I/O Spec"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:39
+#: ../../2.2_samplemotionselector.rst:39
 msgid "Component Name"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:39
+#: ../../2.2_samplemotionselector.rst:39
 msgid "SampleMotionCaller"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:41
+#: ../../2.2_samplemotionselector.rst:41
 msgid "InPort"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:43 ..\..\2.2_samplemotionselector.rst:49
+#: ../../2.2_samplemotionselector.rst:43 ../../2.2_samplemotionselector.rst:49
 msgid "Port Name"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:43 ..\..\2.2_samplemotionselector.rst:45
-#: ..\..\2.2_samplemotionselector.rst:49 ..\..\2.2_samplemotionselector.rst:55
-#: ..\..\2.2_samplemotionselector.rst:57 ..\..\2.2_samplemotionselector.rst:59
+#: ../../2.2_samplemotionselector.rst:43 ../../2.2_samplemotionselector.rst:45
+#: ../../2.2_samplemotionselector.rst:49 ../../2.2_samplemotionselector.rst:55
+#: ../../2.2_samplemotionselector.rst:57 ../../2.2_samplemotionselector.rst:59
 msgid "(None)"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:45 ..\..\2.2_samplemotionselector.rst:51
-#: ..\..\2.2_samplemotionselector.rst:57
+#: ../../2.2_samplemotionselector.rst:45 ../../2.2_samplemotionselector.rst:51
+#: ../../2.2_samplemotionselector.rst:57
 msgid "Data Type"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:47
+#: ../../2.2_samplemotionselector.rst:47
 msgid "OutPort"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:51
+#: ../../2.2_samplemotionselector.rst:51
 msgid "TimedString"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:53
+#: ../../2.2_samplemotionselector.rst:53
 msgid "Configuration"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:55
+#: ../../2.2_samplemotionselector.rst:55
 msgid "Parameter Name"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:59
+#: ../../2.2_samplemotionselector.rst:59
 msgid "Values"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:62
+#: ../../2.2_samplemotionselector.rst:62
 msgid "SampleMotionCaller RTC では、onExecute() コールバックのみ使用します。"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:66
+#: ../../2.2_samplemotionselector.rst:66
 msgid "How to make RTC"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:67
+#: ../../2.2_samplemotionselector.rst:67
 msgid "`RTC Builder` を用いた初期設定は省略します．前章[1_]で習得したことを用い，上記設計を実装して下さい．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:69
+#: ../../2.2_samplemotionselector.rst:69
 msgid "ここで `VC++ 2010` は閉じても構いません．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:72
+#: ../../2.2_samplemotionselector.rst:72
 msgid "ヘッダ，ソースの編集"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:75
+#: ../../2.2_samplemotionselector.rst:75
 msgid ".h, .cpp ファイル編集"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:77
+#: ../../2.2_samplemotionselector.rst:77
 msgid ""
 "`.demo/SampleMotionCaller/include/SampleMotionCaller/SampleMotionCaller.h` "
 "に次のように追加します::"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:84
+#: ../../2.2_samplemotionselector.rst:84
 msgid "下記のように `onExecute()` を実装します．::"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:153
+#: ../../2.2_samplemotionselector.rst:153
 msgid ""
 "ファイル全体はこちらで閲覧可能: - `.demo/SampleMotionCaller/src/SampleMotionCaller.cpp` - "
 "`demo/SampleMotionCaller/include/SampleMotionCaller/SampleMotionCaller.h`"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:158
+#: ../../2.2_samplemotionselector.rst:158
 msgid "CMakeList.txt の編集"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:160
+#: ../../2.2_samplemotionselector.rst:160
 msgid "この RTC では Windows 標準ライブラリのみ使用するので，`CMakeLists.txt` の編集は不要です．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:163
+#: ../../2.2_samplemotionselector.rst:163
 msgid "VC++ によるビルド"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:164
+#: ../../2.2_samplemotionselector.rst:164
 msgid ""
 "Visual C++ 2010 に戻ります．もし既に閉じていれば，再度 `SampleMotionCaller.sln` "
 "ファイルをダブルクリックし，Visual C++ 2010 を起動します．Visual C++ "
@@ -169,59 +169,59 @@ msgid ""
 "<http://www.openrtm.org/openrtm/sites/default/files/1028/VC++_build.png>`_)．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:168
+#: ../../2.2_samplemotionselector.rst:168
 msgid "Visual C++ 2010 のコンソールにエラーが起きたと表示されなければ，以上で RTC 作成が終了です．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:172
+#: ../../2.2_samplemotionselector.rst:172
 msgid "実行方法"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:173
+#: ../../2.2_samplemotionselector.rst:173
 msgid "以下，特に指定ない限り，配布 USB のホームディレクトリに居ることを前提とします．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:179
+#: ../../2.2_samplemotionselector.rst:179
 msgid ""
 "では実行してみましょう． `Choreonoid` 上で `GRobot` を走らせ，`SampleMotionCaller` "
 "から指示を送ってみましょう．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:182
+#: ../../2.2_samplemotionselector.rst:182
 msgid ""
 "`Choreonoid` と `SampleMotionCaller` を簡便に呼び出すための .bat ファイルを既に "
 "`./demo/`SampleMotionCaller` に用意してあります．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:184
+#: ../../2.2_samplemotionselector.rst:184
 msgid ""
 "`./demo/SampleMotionCaller` から "
 "\"0_StartDemo.bat\"，\"1_ConnectRTC.bat\"，\"2_ActivateRTC.bat\" "
 "の順に，下記リンクをクリックして実行．クリックして動作していなそうな場合，Explorer で当該フォルダを開いてそれぞれ実行．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:194
+#: ../../2.2_samplemotionselector.rst:194
 msgid ""
 "RT System Editor で見てみると，`SampleMotionCaller` の RTC "
 "も実行されているのが確認可能．立ち上がるプロンプト内にコマンド情報が表示される．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:196
+#: ../../2.2_samplemotionselector.rst:196
 msgid "のプロンプト上で表示されたコマンドをキーボードから入力．`Choreonoid` 上でロボットが指示に従い動作する"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:198
+#: ../../2.2_samplemotionselector.rst:198
 msgid ""
 "\"3_DeactivateRTC.bat\", \"4_DisconnectRTC.bat\"，\"5_DemoExit.bat\" "
 "の順に実行し，RT システムを停止．"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:219
+#: ../../2.2_samplemotionselector.rst:219
 msgid ""
 "Go back to `index <top.html>`__ | Choose `Other language <index.html>`__"
 msgstr ""
 
-#: ..\..\2.2_samplemotionselector.rst:177
+#: ../../2.2_samplemotionselector.rst:177
 msgid ""
 "For starting necessary services, quickly go [run-common-tools_] and come "
 "back."

--- a/doc/locale/ja/LC_MESSAGES/index.po
+++ b/doc/locale/ja/LC_MESSAGES/index.po
@@ -11,11 +11,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\index.rst:8
+#: ../../index.rst:8
 msgid "RT Middleware Tutorial USB"
 msgstr ""
 
-#: ..\..\index.rst:10
+#: ../../index.rst:10
 msgid ""
 "`日本語 <../../locale/ja/top.html>`_ | `English <../../locale/en/top.html>`_"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/top.po
+++ b/doc/locale/ja/LC_MESSAGES/top.po
@@ -11,54 +11,54 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ..\..\top.rst:3
+#: ../../top.rst:3
 msgid "RT Middleware 体験用チュートリアル用 USB"
 msgstr ""
 
-#: ..\..\top.rst:6
+#: ../../top.rst:6
 msgid "デモの体験"
 msgstr ""
 
-#: ..\..\top.rst:16
+#: ../../top.rst:16
 msgid "RTC 開発の体験"
 msgstr ""
 
-#: ..\..\top.rst:8
+#: ../../top.rst:8
 msgid "`(デモ 1) 画像処理 (OpenRTM-aist，OpenCV) <1.1_demo_imageprocessing.html>`_"
 msgstr ""
 
-#: ..\..\top.rst:9
+#: ../../top.rst:9
 msgid "`(デモ 2) 音声命令による動画再生 (OpenHRI) <1.2_demo_mediaplaybyvoice.html>`_"
 msgstr ""
 
-#: ..\..\top.rst:10
+#: ../../top.rst:10
 msgid ""
 "`(デモ 3) ロボットモーションの新規作成 (Choreonoid) <1.3_choreonoid_createmotion.html>`_"
 msgstr ""
 
-#: ..\..\top.rst:11
+#: ../../top.rst:11
 msgid ""
 "`(デモ 4) 音声命令によるモーションの再生 (OpenHRI，Choreonoid) <1.4_callmotion_byvoice.html>`_"
 msgstr ""
 
-#: ..\..\top.rst:12
+#: ../../top.rst:12
 msgid ""
 "`(デモ 5) 状態遷移モデル変更による，新たなモーション実行 (SEATSAT) <1.5_modifystate_seatsat.html>`_"
 msgstr ""
 
-#: ..\..\top.rst:18
+#: ../../top.rst:18
 msgid ""
 "`(開発 1) 音声認識されたキーワードのログを取得し，時刻とともにファイルに保存する ロガー RTC の開発 "
 "<2.1_samplewordlogger.html>`_"
 msgstr ""
 
-#: ..\..\top.rst:19
+#: ../../top.rst:19
 msgid ""
 "`(開発 2) キーボードからの入力によって Choreonoid のモーションを呼び出すことが出来る RTC の開発 "
 "<2.2_samplemotionselector.html>`_"
 msgstr ""
 
-#: ..\..\top.rst:13
+#: ../../top.rst:13
 msgid "`(デモ 6) アカデミック スカラロボットの制御 <1.6_scararobot_control.html>`_"
 msgstr ""
 


### PR DESCRIPTION
Turned out [sphinx 1.3.1 won't available until Ubuntu 16.04](https://launchpad.net/ubuntu/+source/sphinx). Maybe #35 was made on other platform (presumably Windows?).

Adjusting it back to 1.2.2 makes main maintainers' work on Ubuntu much easier.
